### PR TITLE
Publish to PyPI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,3 +58,24 @@ jobs:
         if: ${{ github.event.repo.name == 'pyodide/pytest-pyodide' }}
         with:
           fail_ci_if_error: true
+  deploy:
+    runs-on: ubuntu-latest
+    environment: PyPi-deploy
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.10.2
+      - name: Install requirements and build wheel
+        shell: bash -l {0}
+        run: |
+          python -m pip install build twine
+          python -m build .
+          twine check dist/*
+      - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,7 @@ jobs:
           fail_ci_if_error: true
   deploy:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     environment: PyPi-deploy
     steps:
       - uses: actions/checkout@v2
@@ -156,9 +157,7 @@ jobs:
         run: |
           python -m pip install build twine
           python -m build .
-          twine check dist/*
       - name: Publish package
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/pyodide/pytest-pyodide/branch/main/graph/badge.svg?token=U7tWHpJj5c)](https://codecov.io/gh/pyodide/pytest-pyodide)
 
 
-Pytest plugin for testing Pyodide and third-party applications that use Pyodide"
+Pytest plugin for testing Pyodide and third-party applications that use Pyodide
 
 ## Installation
 
@@ -19,7 +19,32 @@ You would also one at least one of the following runtimes,
 
 ## Usage
 
-TODO
+1. First you would need a compatible version of Pyodide. You can download the Pyodide build artifacts from releases with,
+   ```
+   wget https://github.com/pyodide/pyodide/releases/download/0.21.0a3/pyodide-build-0.21.0a3.tar.bz2
+   tar xjf pyodide-build-0.21.0a3.tar.bz2
+   mv pyodide dist/
+   ```
+
+2. You can then use the provided fixtures (`selenium`, `selenium_standalone`) in tests,
+   ```py
+   def test_a(selenium):
+       selenium.run("assert 1+1 == 2")   # run Python with Pyodide
+
+   ```
+   which you can run with
+   ```bash
+   pytest --dist-dir=./dist/
+   ```
+3. For convenience, the `run_in_pyodide` decorator is also provided. For
+   instance the above example would be equivalent to,
+   ```py
+   from pytest_pyodide.decorator import run_in_pyodide
+
+   @run_in_pyodide
+   def test_a(selenium):
+       assert 1+1 == 2
+   ```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You would also one at least one of the following runtimes,
 3. For convenience, the `run_in_pyodide` decorator is also provided. For
    instance the above example would be equivalent to,
    ```py
-   from pytest_pyodide.decorator import run_in_pyodide
+   from pytest_pyodide import run_in_pyodide
 
    @run_in_pyodide
    def test_a(selenium):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+
+# Evable versioning via setuptools_scm
+[tool.setuptools_scm]
+
 [tool.mypy]
 python_version = "3.10"
 show_error_codes = true

--- a/pytest_pyodide/__init__.py
+++ b/pytest_pyodide/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from .browser import (
     BrowserWrapper,
     NodeWrapper,
@@ -12,6 +14,12 @@ from .decorator import run_in_pyodide
 from .fixture import *  # noqa: F403, F401
 from .server import spawn_web_server
 from .utils import parse_driver_timeout, set_webdriver_script_timeout
+
+try:
+    __version__ = version("pytest-pyodide")
+except PackageNotFoundError:
+    # package is not installed
+    pass
 
 __all__ = [
     "BrowserWrapper",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pytest-pyodide
-version = 0.21.0.dev0
 author = Pyodide developers
 description = "Pytest plugin for testing Pyodide and third-party applications that use Pyodide"
 long_description = file: README.md


### PR DESCRIPTION
 - Adds minimal "how to use" description in the readme (closes #6 )
 - Enables setuptools_scm to get the version from the git tag. For release one only need to tag (there is no need to manually specify version). 
 - Add CI setup to publish to PyPI. @ryanking13 please remind me your PyPI username, I'll add to there. 

For now, I just uploaded a test version to make sure the rendering is OK https://pypi.org/project/pytest-pyodide/. 

I'm not really sure what we should do about versions:
 a) either we make the versioning be completely independent and start say with 0.1.0
 b) or we try to follow Pyodide versions but then it means we can't easily use semver

In any case, version x of this package would likely work only with some range of pyodide versions (at least those that we check in CI).