### PR TITLE
Handle xfail_browsers marker

### DIFF
--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -10,6 +10,8 @@ from _pytest.python import (
     pytest_pycollect_makemodule as orig_pytest_pycollect_makemodule,
 )
 
+from .utils import parse_xfail_browsers
+
 RUNTIMES = ["firefox", "chrome", "node"]
 
 
@@ -122,3 +124,24 @@ def pytest_collection_modifyitems(items: list[Any]) -> None:
             item.config.option.runtime != "host" and "runtime" not in item.fixturenames
         ):
             item.add_marker(pytest.mark.skip(reason="Host test"))
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+
+    browser = None
+    for fixture in item._fixtureinfo.argnames:
+        if fixture.startswith("selenium"):
+            browser = item.funcargs[fixture]
+            break
+
+    if not browser:
+        yield
+        return
+
+    xfail_msg = parse_xfail_browsers(item).get(browser.browser, None)
+    if xfail_msg is not None:
+        pytest.xfail(xfail_msg)
+
+    yield
+    return

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -1,0 +1,11 @@
+import pytest
+
+from pytest_pyodide import run_in_pyodide
+
+
+@pytest.mark.xfail_browsers(
+    node="Should xfail", firefox="Should xfail", chrome="Should xfail"
+)
+@run_in_pyodide
+def test_xfail_browser(selenium):
+    raise AssertionError("This test should xfail")


### PR DESCRIPTION
Migrates `xfail_browsers` marker from the [Pyodide main repository](https://github.com/pyodide/pyodide/blob/e673fde7cfda83fb63ac998708cc07b8d6fd77b0/conftest.py#L128-L163)