### PR TITLE
Use forked tblib and clean up tracebacks

### DIFF
--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -79,7 +79,12 @@ def _create_outer_test_function(
     # Make onwards call with two args:
     # 1. <selenium_arg_name>
     # 2. all other arguments in a tuple
-    func_body = ast.parse("__tracebackhide__ = True; return run_test(selenium_arg_name, (arg1, arg2, ...))").body
+    func_body = ast.parse(
+        """\
+        __tracebackhide__ = True; \
+        return run_test(selenium_arg_name, (arg1, arg2, ...)) \
+        """.strip()
+    ).body
     onwards_call = func_body[1].value  # type: ignore[attr-defined]
     onwards_call.func = ast.Name(id=run_test_id, ctx=ast.Load())
     onwards_call.args[0].id = selenium_arg_name  # Set variable name

--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -79,8 +79,8 @@ def _create_outer_test_function(
     # Make onwards call with two args:
     # 1. <selenium_arg_name>
     # 2. all other arguments in a tuple
-    func_body = ast.parse("return run_test(selenium_arg_name, (arg1, arg2, ...))").body
-    onwards_call = func_body[0].value  # type: ignore[attr-defined]
+    func_body = ast.parse("__tracebackhide__ = True; return run_test(selenium_arg_name, (arg1, arg2, ...))").body
+    onwards_call = func_body[1].value  # type: ignore[attr-defined]
     onwards_call.func = ast.Name(id=run_test_id, ctx=ast.Load())
     onwards_call.args[0].id = selenium_arg_name  # Set variable name
     onwards_call.args[1].elts = [  # Set tuple elements
@@ -182,6 +182,7 @@ class run_in_pyodide:
         """
         return f"""
         async def __tmp():
+            __tracebackhide__ = True
             from base64 import b64encode, b64decode
             import pickle
             mod = pickle.loads(b64decode({_encode(self._mod)!r}))
@@ -214,6 +215,7 @@ class run_in_pyodide:
     def _run_test(self, selenium: SeleniumType, args: tuple):
         """The main test runner, called from the AST generated in
         _create_outer_test_function."""
+        __tracebackhide__ = True
         code = self._code_template(args)
         if self._pkgs:
             selenium.load_package(self._pkgs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     hypothesis
     selenium
     playwright
-    tblib
+    pyodide-tblib
 
 # This is required to add node driver code to the package.
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     hypothesis
     selenium
     playwright
-    pyodide-tblib
+    pyodide-tblib # Forked to add https://github.com/ionelmc/python-tblib/pull/66
 
 # This is required to add node driver code to the package.
 [options.package_data]


### PR DESCRIPTION
This is paired with https://github.com/pyodide/pyodide/pull/2944. 
It uses a fork of tblib with this patch:
https://github.com/ionelmc/python-tblib/pull/66

Consider the following test:
```py
@run_in_pyodide
def test_blah(selenium):
    def f():
        raise Exception("hi!")
    f()
```
Before this PR:
```py
pytest-pyodide/pytest_pyodide/decorator.py:99: in test_blah
    run_test(selenium_arg_name, (arg1, arg2, ...))
pytest-pyodide/pytest_pyodide/decorator.py:226: in _run_test
    raise result
<exec>:13: in __tmp
    ???
src/tests/test_file:5: in test_blah
    f()
src/tests/test_file:4: in f
    raise Exception("hi!")
E   Exception: hi!
```
After this PR:
```py
src/tests/test_file:5: in test_blah
    f()
src/tests/test_file:4: in f
    raise Exception("hi!")
E   Exception: hi!
```