### PR TITLE
Add Safari runner for selenium

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,6 +123,8 @@ jobs:
         if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'safari' && contains(runner.os, 'macos') }}
         run: |
           sudo safaridriver --enable
+          # Only one Safari browser instance can be active at any given time
+          echo "STANDALONE_REFRESH=1" >> $GITHUB_ENV
 
       - name: Install requirements
         shell: bash -l {0}
@@ -144,7 +146,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          pytest -v \
+          STANDALONE_REFRESH=${{ env.STANDALONE_REFRESH }} pytest -v \
             --cov=pytest_pyodide \
             --dist-dir=./dist/ \
             --runner=${{ matrix.test-config.runner }} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         id: cache-pyodide
         with:
           path: dist
-          key: ${{ runner.os }}-pyodide-${{ matrix.pyodide-version }}-${{ hashFiles('.github/**/*.yml') }}
+          key: pyodide-${{ matrix.pyodide-version }}-${{ hashFiles('.github/**/*.yml') }}
 
       - name: Download Pyodide
         shell: bash -l {0}
@@ -119,7 +119,6 @@ jobs:
         if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'chrome' }}
         uses: nanasess/setup-chromedriver@v1
 
-      # Adapted from: https://circleci.com/developer/orbs/orb/circleci/macos
       - name: Enable Safari Driver
         if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'safari' && contains(runner.os, 'macos') }}
         run: |
@@ -140,7 +139,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: dist
-          key: ${{ runner.os }}-pyodide-${{ matrix.pyodide-version }}-${{ hashFiles('.github/**/*.yml') }}
+          key: pyodide-${{ matrix.pyodide-version }}-${{ hashFiles('.github/**/*.yml') }}
 
       - name: Run tests
         shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,13 +119,11 @@ jobs:
         if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'chrome' }}
         uses: nanasess/setup-chromedriver@v1
 
-      # Adapted from: https://github.com/Choices-js/Choices/blob/master/.github/workflows/browsers.yml
+      # Adapted from: https://circleci.com/developer/orbs/orb/circleci/macos
       - name: Enable Safari Driver
         if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'safari' && contains(runner.os, 'macos') }}
         run: |
-          mkdir -p ~/Library/WebDriver/
-          curl https://raw.githubusercontent.com/web-platform-tests/wpt/master/tools/ci/azure/com.apple.Safari.plist -o ~/Library/WebDriver/com.apple.Safari.plist
-          defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
+          sudo safaridriver --enable
 
       - name: Install requirements
         shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,12 +45,13 @@ jobs:
 
   test:
     needs: download-pyodide
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       DISPLAY: :99
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         pyodide-version: [0.21.0a3, 0.21.0]
         test-config: [
           {runner: selenium, runtime: firefox, firefox-version: latest, geckodriver-version: latest },
@@ -63,6 +64,11 @@ jobs:
           {runner: playwright, runtime: firefox, playwright-version: 1.22.0, node-version: 18},
           {runner: playwright, runtime: chrome, playwright-version: 1.22.0, node-version: 18},
         ]
+        include:
+          - os: macos-latest
+            pyodide-version: 0.21.0
+            test-config: {runner: selenium, runtime: safari }
+
     steps:
       - uses: actions/checkout@v2
 
@@ -87,9 +93,9 @@ jobs:
         shell: bash -l {0}
         if: ${{ matrix.test-config.runner == 'playwright' }}
         run: |
-          pip install playwright==${{ matrix.test-config.playwright-version }}
+          python3 -m pip install playwright==${{ matrix.test-config.playwright-version }}
           # TODO: install only browsers that are required
-          python -m playwright install --with-deps
+          python3 -m playwright install --with-deps
 
       - name: Install firefox
         uses: browser-actions/setup-firefox@latest
@@ -113,15 +119,23 @@ jobs:
         if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'chrome' }}
         uses: nanasess/setup-chromedriver@v1
 
+      # Adapted from: https://github.com/Choices-js/Choices/blob/master/.github/workflows/browsers.yml
+      - name: Enable Safari Driver
+        if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'safari' && contains(runner.os, 'macos') }}
+        run: |
+          mkdir -p ~/Library/WebDriver/
+          curl https://raw.githubusercontent.com/web-platform-tests/wpt/master/tools/ci/azure/com.apple.Safari.plist -o ~/Library/WebDriver/com.apple.Safari.plist
+          defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
+
       - name: Install requirements
         shell: bash -l {0}
         run: |
-          pip install -e .
-          pip install pytest-cov
+          python3 -m pip install -e .
+          python3 -m pip install pytest-cov
           # Currently we only install the package for dependencies.
           # We then uninstall it otherwise tests fails due to pytest hook being
           # registered twice.
-          pip uninstall -y pytest-pyodide
+          python3 -m pip uninstall -y pytest-pyodide
           which npm && npm install node-fetch@2
 
       - name: Get Pyodide from cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.21.2] - Unreleased
+## [0.22.0] - 2022.09.02
 
 - Add `selenium_standalone_refresh` fixture ([#27](https://github.com/pyodide/pytest-pyodide/pull/27))
 - Add selenium safari support ([#27](https://github.com/pyodide/pytest-pyodide/pull/27))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.21.2] - Unreleased
+
+- Add `selenium_standalone_refresh` fixture ([#27](https://github.com/pyodide/pytest-pyodide/pull/27))
+- Add selenium safari support ([#27](https://github.com/pyodide/pytest-pyodide/pull/27))
+
 ## [0.21.1] - 2022.08.10
 
 - Use forked tblib and clean up tracebacks ([#22](https://github.com/pyodide/pytest-pyodide/pull/22))

--- a/pytest_pyodide/__init__.py
+++ b/pytest_pyodide/__init__.py
@@ -7,6 +7,7 @@ from .runner import (
     PlaywrightFirefoxRunner,
     SeleniumChromeRunner,
     SeleniumFirefoxRunner,
+    SeleniumSafariRunner,
 )
 from .server import spawn_web_server
 from .utils import parse_driver_timeout, set_webdriver_script_timeout
@@ -23,6 +24,7 @@ __all__ = [
     "PlaywrightFirefoxRunner",
     "SeleniumChromeRunner",
     "SeleniumFirefoxRunner",
+    "SeleniumSafariRunner",
     "set_webdriver_script_timeout",
     "parse_driver_timeout",
     "run_in_pyodide",

--- a/pytest_pyodide/fixture.py
+++ b/pytest_pyodide/fixture.py
@@ -117,6 +117,30 @@ def selenium_standalone(request, runtime, web_server_main, playwright_browsers):
                 print(selenium.logs)
 
 
+@pytest.fixture(scope="function")
+def selenium_standalone_refresh(selenium):
+    """
+    Experimental standalone fixture which refreshes a page instead of
+    instantiating a new webdriver session.
+
+    by setting STANDALONE_REFRESH env variable,
+    selenium_standalone_refresh fixture will override selenium_standalone
+    """
+    selenium.clean_logs()
+
+    yield selenium
+
+    selenium.refresh()
+    selenium.load_pyodide()
+    selenium.initialize_pyodide()
+    selenium.save_state()
+    selenium.restore_state()
+
+
+if os.environ.get("STANDALONE_REFRESH"):
+    selenium_standalone = selenium_standalone_refresh  # type: ignore[assignment] # noqa: F811
+
+
 @pytest.fixture(scope="module")
 def selenium_esm(request, runtime, web_server_main, playwright_browsers):
     with selenium_common(

--- a/pytest_pyodide/fixture.py
+++ b/pytest_pyodide/fixture.py
@@ -10,6 +10,7 @@ from .runner import (
     PlaywrightFirefoxRunner,
     SeleniumChromeRunner,
     SeleniumFirefoxRunner,
+    SeleniumSafariRunner,
     _BrowserBaseRunner,
 )
 from .server import spawn_web_server
@@ -75,6 +76,7 @@ def selenium_common(
     browser_set = {
         ("selenium", "firefox"): SeleniumFirefoxRunner,
         ("selenium", "chrome"): SeleniumChromeRunner,
+        ("selenium", "safari"): SeleniumSafariRunner,
         ("selenium", "node"): NodeRunner,
         ("playwright", "firefox"): PlaywrightFirefoxRunner,
         ("playwright", "chrome"): PlaywrightChromeRunner,

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -12,7 +12,7 @@ from _pytest.python import (
 
 from .utils import parse_xfail_browsers
 
-RUNTIMES = ["firefox", "chrome", "node"]
+RUNTIMES = ["firefox", "chrome", "safari", "node"]
 
 
 def pytest_configure(config):

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -100,6 +100,7 @@ class JavascriptException(Exception):
 
 class _BrowserBaseRunner:
     browser = ""
+    script_timeout = 20
     JavascriptException = JavascriptException
 
     def __init__(
@@ -108,7 +109,6 @@ class _BrowserBaseRunner:
         server_hostname="127.0.0.1",
         server_log=None,
         load_pyodide=True,
-        script_timeout=20,
         script_type="classic",
         dist_dir=None,
         *args,
@@ -121,8 +121,7 @@ class _BrowserBaseRunner:
         self.script_type = script_type
         self.dist_dir = dist_dir
         self.driver = self.get_driver()
-        self.set_script_timeout(script_timeout)
-        self.script_timeout = script_timeout
+        self.set_script_timeout(self.script_timeout)
         self.prepare_driver()
         self.javascript_setup()
         if load_pyodide:
@@ -321,6 +320,7 @@ class _SeleniumBaseRunner(_BrowserBaseRunner):
 
     def set_script_timeout(self, timeout):
         self.driver.set_script_timeout(timeout)
+        self.script_timeout = timeout
 
     def quit(self):
         self.driver.quit()
@@ -433,6 +433,20 @@ class SeleniumChromeRunner(_SeleniumBaseRunner):
         self.driver.execute_cdp_cmd("HeapProfiler.collectGarbage", {})
 
 
+class SeleniumSafariRunner(_SeleniumBaseRunner):
+
+    browser = "safari"
+    script_timeout = 30
+
+    def get_driver(self):
+        from selenium.webdriver import Safari
+        from selenium.webdriver.safari.options import Options
+
+        options = Options()
+
+        return Safari(options=options)
+
+
 class PlaywrightChromeRunner(_PlaywrightBaseRunner):
     browser = "chrome"
 
@@ -487,7 +501,7 @@ class NodeRunner(_BrowserBaseRunner):
         pass
 
     def set_script_timeout(self, timeout):
-        self._timeout = timeout
+        self.script_timeout = timeout
 
     def quit(self):
         self.p.sendeof()
@@ -523,7 +537,7 @@ class NodeRunner(_BrowserBaseRunner):
         self.p.sendline(cmd_id)
         self.p.sendline(wrapped)
         self.p.sendline(cmd_id)
-        self.p.expect_exact(f"{cmd_id}:UUID\r\n", timeout=self._timeout)
+        self.p.expect_exact(f"{cmd_id}:UUID\r\n", timeout=self.script_timeout)
         self.p.expect_exact(f"{cmd_id}:UUID\r\n")
         if self.p.before:
             self._logs.append(self.p.before.decode()[:-2].replace("\r", ""))

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -443,7 +443,6 @@ class SeleniumSafariRunner(_SeleniumBaseRunner):
         from selenium.webdriver.safari.options import Options
 
         options = Options()
-
         return Safari(options=options)
 
 

--- a/pytest_pyodide/server.py
+++ b/pytest_pyodide/server.py
@@ -12,7 +12,6 @@ import tempfile
 
 @contextlib.contextmanager
 def spawn_web_server(dist_dir):
-
     tmp_dir = tempfile.mkdtemp()
     log_path = pathlib.Path(tmp_dir) / "http-server.log"
     q: multiprocessing.Queue[str] = multiprocessing.Queue()
@@ -20,7 +19,7 @@ def spawn_web_server(dist_dir):
 
     try:
         p.start()
-        port = q.get()
+        port = q.get(timeout=20)
         hostname = "127.0.0.1"
 
         print(

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -112,6 +112,7 @@ def test_local_fail_load_package(selenium_standalone):
     def _load_package_error(*args, **kwargs):
         raise OSError("STOP!")
 
+    _load_package_original = selenium.load_package
     selenium.load_package = _load_package_error
 
     exc = None
@@ -119,6 +120,8 @@ def test_local_fail_load_package(selenium_standalone):
         example_func(selenium)
     except OSError:
         exc = pytest.ExceptionInfo.from_current()
+    finally:
+        selenium.load_package = _load_package_original
 
     assert exc
     try:

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -4,7 +4,10 @@ from pytest_pyodide import run_in_pyodide
 
 
 @pytest.mark.xfail_browsers(
-    node="Should xfail", firefox="Should xfail", chrome="Should xfail"
+    node="Should xfail",
+    firefox="Should xfail",
+    chrome="Should xfail",
+    safari="Should xfail",
 )
 @run_in_pyodide
 def test_xfail_browser(selenium):


### PR DESCRIPTION
Adds safari runner for selenium, mostly adopted from @rth's PR in Pyodide https://github.com/pyodide/pyodide/pull/2578

I also added `selenium_standalone_refresh` fixture which I experimented in https://github.com/pyodide/pyodide/pull/2957.
Since selenium allows only one Safari browser instance active at any given time, the original `selenium_standalone` is not very suitable for Safari test.

I am not sure whether we should fully replace `selenium_standalone` with `selenium_standalone_refresh`, as it is not tested very much yet. So I made a separate fixture and add an option (`STANDALONE_REFRESH` env variable) which dynamically overrides `selenium_standalone` with `selenium_standalone_refresh`. I am open to better ideas.