### PR TITLE
Re-order safari test order to make sure only one session exists during the test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,10 @@ jobs:
         include:
           - os: macos-latest
             pyodide-version: 0.21.0
-            test-config: {runner: selenium, runtime: safari }
+            test-config: {runner: selenium, runtime: safari}
+          - os: macos-latest
+            pyodide-version: 0.21.0
+            test-config: {runner: selenium, runtime: safari, refresh: 1 }
 
     steps:
       - uses: actions/checkout@v2
@@ -124,7 +127,7 @@ jobs:
         run: |
           sudo safaridriver --enable
           # Only one Safari browser instance can be active at any given time
-          echo "STANDALONE_REFRESH=1" >> $GITHUB_ENV
+          echo "STANDALONE_REFRESH=${{ matrix.test-config.refresh }}" >> $GITHUB_ENV
 
       - name: Install requirements
         shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.22.1] - unreleased
+
+- Re-order safari tests to make sure only one simultaneous session exists during the test ([#28](https://github.com/pyodide/pytest-pyodide/pull/28))
+
 ## [0.22.0] - 2022.09.02
 
 - Add `selenium_standalone_refresh` fixture ([#27](https://github.com/pyodide/pytest-pyodide/pull/27))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.22.1] - unreleased
+## [0.22.1] - 2002.09.06
 
 - Re-order safari tests to make sure only one simultaneous session exists during the test ([#29](https://github.com/pyodide/pytest-pyodide/pull/29))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.22.1] - unreleased
 
-- Re-order safari tests to make sure only one simultaneous session exists during the test ([#28](https://github.com/pyodide/pytest-pyodide/pull/28))
+- Re-order safari tests to make sure only one simultaneous session exists during the test ([#29](https://github.com/pyodide/pytest-pyodide/pull/29))
 
 ## [0.22.0] - 2022.09.02
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pip install pytest-pyodide
 You would also one at least one of the following runtimes,
  - Chrome and chromedriver
  - Firefox and geckodriver
+ - Safari and safaridriver
  - node v14+
 
 ## Usage
@@ -116,7 +117,8 @@ Possible options for `--runtime` are:
 - node (default)
 - firefox
 - chrome
-- all (chrome + firefox + node)
+- safari
+- all (chrome + firefox + safari + node)
 - host (do not run browser-based tests)
 
 ```sh

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -150,7 +150,7 @@ def pytest_collection_modifyitems(items: list[Any]) -> None:
     def _get_item_position(item):
         counter[0] += 1
         if any(
-            [re.match(r"^safari[\-$]", el) for el in item.keywords._markers.keys()]
+            [re.match(r"^safari[\-$]?", el) for el in item.keywords._markers.keys()]
         ) and _has_standalone_fixture(item._request.fixturenames):
             return counter[0] - OFFSET
         return counter[0]


### PR DESCRIPTION
This is also adapted from https://github.com/pyodide/pyodide/pull/2578, I found that there are some more "standalone" fixtures that needs to be handled...