### PR TITLE
Run host tests by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
           {runner: selenium, runtime: node, node-version: 14},
           {runner: selenium, runtime: node, node-version: 16},
           {runner: selenium, runtime: node, node-version: 18},
+          {runner: selenium, runtime: firefox-no-host, firefox-version: latest, geckodriver-version: latest },
           {runner: selenium, runtime: host},
           # playwright browser versions are pinned to playwright version
           {runner: playwright, runtime: firefox, playwright-version: 1.22.0, node-version: 18},
@@ -81,7 +82,7 @@ jobs:
 
       - name: Install node
         uses: actions/setup-node@v3
-        if: ${{ matrix.test-config.runtime == 'node' || matrix.test-config.runner == 'playwright' }}
+        if: ${{ contains(matrix.test-config.runtime, 'node') || matrix.test-config.runner == 'playwright' }}
         with:
           node-version: ${{ matrix.test-config.node-version }}
 
@@ -102,28 +103,28 @@ jobs:
 
       - name: Install firefox
         uses: browser-actions/setup-firefox@latest
-        if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'firefox' }}
+        if: ${{ matrix.test-config.runner == 'selenium' && contains(matrix.test-config.runtime, 'firefox') }}
         with:
           firefox-version: ${{ matrix.test-config.firefox-version }}
 
       - name: Install geckodriver
         uses: browser-actions/setup-geckodriver@latest
-        if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'firefox' }}
+        if: ${{ matrix.test-config.runner == 'selenium' && contains(matrix.test-config.runtime, 'firefox') }}
         with:
           geckodriver-version: ${{ matrix.test-config.geckodriver-version }}
 
       - name: Install chrome
         uses: browser-actions/setup-chrome@latest
-        if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'chrome' }}
+        if: ${{ matrix.test-config.runner == 'selenium' && contains(matrix.test-config.runtime, 'chrome') }}
         with:
           chrome-version: ${{ matrix.test-config.geckodriver-version }}
 
       - name: Install chromedriver
-        if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'chrome' }}
+        if: ${{ matrix.test-config.runner == 'selenium' && contains(matrix.test-config.runtime, 'chrome') }}
         uses: nanasess/setup-chromedriver@v1
 
       - name: Enable Safari Driver
-        if: ${{ matrix.test-config.runner == 'selenium' && matrix.test-config.runtime == 'safari' && contains(runner.os, 'macos') }}
+        if: ${{ matrix.test-config.runner == 'selenium' && contains(matrix.test-config.runtime, 'safari') && contains(runner.os, 'macos') }}
         run: |
           sudo safaridriver --enable
           # Only one Safari browser instance can be active at any given time

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,11 @@ jobs:
           {runner: selenium, runtime: node, node-version: 16},
           {runner: selenium, runtime: node, node-version: 18},
           {runner: selenium, runtime: firefox-no-host, firefox-version: latest, geckodriver-version: latest },
+          {
+            runner: selenium, runtime: chrome firefox,
+            firefox-version: latest, geckodriver-version: latest,
+            chrome-version: latest, chromedriver-version: latest,
+          },
           {runner: selenium, runtime: host},
           # playwright browser versions are pinned to playwright version
           {runner: playwright, runtime: firefox, playwright-version: 1.22.0, node-version: 18},

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,7 +159,7 @@ jobs:
             --cov=pytest_pyodide \
             --dist-dir=./dist/ \
             --runner=${{ matrix.test-config.runner }} \
-            --rt=${{ matrix.test-config.runtime }}
+            --rt ${{ matrix.test-config.runtime }}
 
       - uses: codecov/codecov-action@v3
         if: ${{ github.event.repo.name == 'pyodide/pytest-pyodide' || github.event_name == 'pull_request' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.22.2] - 2002.09.08
+
+- Host tests will now run by default. If you want to disable running host tests, add `-no-host` suffix in the `--runtime` option. ([#33](https://github.com/pyodide/pytest-pyodide/pull/33))
+- Multiple browser testing is now available by passing `--runtime` option multiple times. ([#33](https://github.com/pyodide/pytest-pyodide/pull/33))
+
 ## [0.22.1] - 2002.09.06
 
 - Re-order safari tests to make sure only one simultaneous session exists during the test ([#29](https://github.com/pyodide/pytest-pyodide/pull/29))

--- a/README.md
+++ b/README.md
@@ -118,11 +118,14 @@ Possible options for `--runtime` are:
 - firefox
 - chrome
 - safari
-- all (chrome + firefox + safari + node)
 - host (do not run browser-based tests)
 
 ```sh
 pytest --runtime firefox
+pytest --runtime firefox --runtime chrome
+
+# Adding -no-host suffix will disable running host tests
+pytest --runtime chrome-no-host
 ```
 
 ## Running tests with Playwright (optional)

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -124,7 +124,7 @@ def pytest_generate_tests(metafunc: Any) -> None:
 
             runtime_filtered.append(rt)
 
-        metafunc.parametrize("runtime", [runtime_filtered], scope="module")
+        metafunc.parametrize("runtime", runtime_filtered, scope="module")
 
 
 def pytest_collection_modifyitems(items: list[Any]) -> None:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -9,12 +9,12 @@ def test_web_server_secondary(selenium, web_server_secondary):
 
 def test_host(request):
     runtime = request.config.option.runtime
-    assert runtime == "host", "this test should only run when runtime is host"
+    assert "host" in runtime, "this test should only run when runtime includes host"
 
 
 def test_runtime(selenium, request):
     runtime = request.config.option.runtime
-    assert runtime != "host", "this test should only run when runtime is not host"
+    assert "host" not in runtime, "this test should only run when runtime is not host"
 
 
 def test_doctest():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,5 +1,7 @@
 import pathlib
 
+import pytest
+
 
 def test_web_server_secondary(selenium, web_server_secondary):
     host, port, logs = web_server_secondary
@@ -7,14 +9,16 @@ def test_web_server_secondary(selenium, web_server_secondary):
     assert selenium.server_port != port
 
 
-def test_host(request):
-    runtime = request.config.option.runtime
-    assert "host" in runtime, "this test should only run when runtime includes host"
+def test_host():
+    assert (
+        pytest.pyodide_run_host_test
+    ), "this test should only run when host test is enabled"
 
 
-def test_runtime(selenium, request):
-    runtime = request.config.option.runtime
-    assert "host" not in runtime, "this test should only run when runtime is not host"
+def test_runtime(selenium):
+    assert (
+        pytest.pyodide_runtimes
+    ), "this test should only run when runtime is specified"
 
 
 def test_doctest():


### PR DESCRIPTION
Close #32 

The changes that I made in this PR are:

1. Run host tests by default, unless `-no-host` is given (e.g. `chrome-no-host`, `firefox-no-host`).
2. Remove the option `all` and support passing list of runtimes. (e.g. `--rt chrome --rt firefox`)
    - I found that the option `all` was acutally not working correctly.

- [x] changelog