### PR TITLE
Better explain what it means when you get a ModuleNotFound error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## [0.22.3] - 2022.10.12
+## [Unreleased]
 
 - `JsException` raise from within pyodide is now unpickled correctly in the host. ([#45](https://github.com/pyodide/pytest-pyodide/issues/45))
+- Improve error messages when unpickling error messages with objects that don't exist in the host environment
+   ([#46](https://github.com/pyodide/pytest-pyodide/issues/46))
 
 ## [0.22.2] - 2022.09.08
 

--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -60,7 +60,7 @@ def _decode(result: str) -> Any:
             f"There was a problem with unpickling the return value/exception from your pyodide environment. "
             f"This usually means the type of the return value does not exist in your host environment. "
             f"The original message is: {exc}. "
-        )
+        ) from None
 
 
 def _create_outer_test_function(

--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -53,7 +53,14 @@ def _decode(result: str) -> Any:
     buffer = BytesIO()
     buffer.write(b64decode(result))
     buffer.seek(0)
-    return Unpickler(buffer).load()
+    try:
+        return Unpickler(buffer).load()
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            f"There was a problem with unpickling the return value/exception from your pyodide environment. "
+            f"This usually means the type of the return value does not exist in your host environment. "
+            f"The original message is: {exc}. "
+        )
 
 
 def _create_outer_test_function(

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -84,6 +84,23 @@ def test_inner_function_js_exception(selenium):
         inner_function(selenium)
 
 
+def test_not_unpickable_return_value(selenium):
+    @run_in_pyodide
+    async def inner_function(selenium):
+        with open("some_module.py", "w") as fp:
+            fp.write("class Test: pass\n")
+
+        from some_module import Test
+
+        return Test()
+
+    with pytest.raises(
+            ModuleNotFoundError,
+            match="There was a problem with unpickling the return.*",
+    ):
+        inner_function(selenium)
+
+
 def complicated_decorator(attr_name: str):
     def inner_func(value):
         def dec(func):


### PR DESCRIPTION
When you use a package/module in your pyodide tests which is not available in your host environment you get a `ModuleNotFoundError` exception. It is not trivial from the exception nor the traceback why this exception happened.

In this PR I added some more explanation when this exception happens and tell the user why it happened.