### PR TITLE
Unpickle PyodideHandle into actual Pyodide object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+- Breaking: altered the way that `PyodideHandle` is received inside the Pyodide
+  function so that it is transparent to the callee: the handle is automatically
+  converted into the wrapped object.
+  [#54](https://github.com/pyodide/pytest-pyodide/pull/54)
+
 ## [0.23.0] - 2022.10.24
 
 - `JsException` raise from within pyodide is now unpickled correctly in the host. ([#45](https://github.com/pyodide/pytest-pyodide/issues/45))

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ def get_pyodide_handle(selenium):
 
 @run_in_pyodide
 def set_value(selenium, h, key, value):
-    h.obj[key] = value
+    h[key] = value
 
 @run_in_pyodide
 def get_value(selenium, h, key, value):
-    return h.obj[key]
+    return h[key]
 
 def test_pyodide_handle(selenium):
     h = get_pyodide_handle(selenium)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -235,13 +235,13 @@ def test_run_in_pyodide_alias(request):
 
 
 @run_in_pyodide
-def set_handle(selenium, handle, key, value):
-    handle.obj[key] = value
+def set_handle(selenium, d, key, value):
+    d[key] = value
 
 
 @run_in_pyodide
-def assert_get_handle(selenium, handle, key, value):
-    assert handle.obj[key] == value
+def assert_get_handle(selenium, d, key, value):
+    assert d[key] == value
 
 
 @run_in_pyodide


### PR DESCRIPTION
It turns out that the way I wrote PyodideHandle is pretty annoying to use. See for instance in https://github.com/pyodide/pyodide/pull/3184. This makes it unpickle to the actual object so it doesn't look so awkward. In particular, this way only the fixture has to bother with the `PyodideHandle` stuff. The consuming tests can act like it is a perfectly normal argument.