### PR TITLE
CI Pin OS versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
         self-build: 1
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     environment: PyPi-deploy
     steps:
@@ -37,7 +37,7 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/filtermatrix.py
+++ b/.github/workflows/filtermatrix.py
@@ -15,7 +15,7 @@ if pyodide_versions == "*":
 
 matrix = yaml.safe_load(
     """
-os: [ubuntu-latest]
+os: [ubuntu-20.04]
 pyodide-version: """
     + pyodide_versions
     + """
@@ -37,10 +37,10 @@ test-config: [
     {runner: playwright, browser: chrome, runner-version: 1.22.0, driver-version: 18},
 ]
 include:
-    - os: macos-latest
+    - os: macos-11
       pyodide-version: 0.21.0
       test-config: {runner: selenium, browser: safari}
-    - os: macos-latest
+    - os: macos-11
       pyodide-version: 0.21.0
       test-config: {runner: selenium, browser: safari, refresh: 1 }
 """

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -96,12 +96,12 @@ jobs:
         run: |
           if [ -n "${{ inputs.runner-version }}" ]
           then
-            python3 -m pip install playwright==${{inputs.runner-version}}
+            python3.10 -m pip install playwright==${{inputs.runner-version}}
           else
-            python3 -m pip install playwright
+            python3.10 -m pip install playwright
           fi
           # TODO: install only browsers that are required
-          python3 -m playwright install --with-deps
+          python3.10 -m playwright install --with-deps
 
       - name: Install firefox
         uses: browser-actions/setup-firefox@latest
@@ -136,20 +136,20 @@ jobs:
         shell: bash -l {0}
         if: inputs.self-build==1
         run: |
-          python3 -m pip install -e .
-          python3 -m pip install pytest-cov
+          python3.10 -m pip install -e .
+          python3.10 -m pip install pytest-cov
           # Currently we only install the package for dependencies.
           # We then uninstall it otherwise tests fails due to pytest hook being
           # registered twice.
-          python3 -m pip uninstall -y pytest-pyodide
+          python3.10 -m pip uninstall -y pytest-pyodide
           which npm && npm install -g npm && npm update
           which npm && npm install node-fetch@2
       - name: Install pytest-pyodide for workflow
         shell: bash -l {0}
         if: inputs.self-build!=1
         run: |
-          python3 -m pip install pytest-pyodide
-          python3 -m pip install pytest-cov
+          python3.10 -m pip install pytest-pyodide
+          python3.10 -m pip install pytest-cov
           which npm && npm install -g npm && npm update
           which npm && npm install node-fetch@2
       - name: Get Pyodide from cache

--- a/.github/workflows/testall.yaml
+++ b/.github/workflows/testall.yaml
@@ -27,7 +27,7 @@ on:
       os:
         required: false
         type: string
-        default: '[ubuntu-latest,macos-latest]'
+        default: '[ubuntu-20.04,macos-11]'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Latest runners of GHA comes with Python 3.11 (macos-latest) or it does not support installing Python 3.10.2 with `setup-python` actions (ubuntu-latest).