### PR TITLE
Remove STANDALONE_REFRESH env variable

### DIFF
--- a/.github/workflows/filtermatrix.py
+++ b/.github/workflows/filtermatrix.py
@@ -40,9 +40,6 @@ include:
     - os: macos-11
       pyodide-version: 0.21.0
       test-config: {runner: selenium, browser: safari}
-    - os: macos-11
-      pyodide-version: 0.21.0
-      test-config: {runner: selenium, browser: safari, refresh: 1 }
 """
 )
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,10 +40,6 @@ on:
         required: false
         type: string
         default: "latest"
-      refresh:
-        required: false
-        type: string
-        default: "0"
 permissions:
   contents: read
 
@@ -129,8 +125,6 @@ jobs:
         if: ${{ inputs.runner == 'selenium' && contains(inputs.browser, 'safari') && contains(runner.os, 'macos') }}
         run: |
           sudo safaridriver --enable
-          # Only one Safari browser instance can be active at any given time
-          echo "STANDALONE_REFRESH=${{ inputs.refresh }}" >> $GITHUB_ENV
 
       - name: Install requirements
         shell: bash -l {0}
@@ -161,7 +155,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          STANDALONE_REFRESH=${{ env.STANDALONE_REFRESH }} pytest -v \
+          pytest -v \
             --cov=pytest_pyodide \
             --dist-dir=./pyodide-dist/ \
             --runner=${{ inputs.runner }} \

--- a/.github/workflows/testall.yaml
+++ b/.github/workflows/testall.yaml
@@ -66,5 +66,4 @@ jobs:
       os: ${{ matrix.os }}
       browser-version: ${{ matrix.test-config.browser-version }}
       driver-version: ${{ matrix.test-config.driver-version }}
-      refresh: ${{ matrix.test-config.refresh }}
       runner-version: ${{ matrix.test-config.runner-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+- Breaking: removed STANDALONE_REFRESH env variable which was used to
+  override `selenium_standalone` fixture with `selenium_standalone_refresh`.
+  [#65](https://github.com/pyodide/pytest-pyodide/pull/65)
+
 ## [0.23.2] - 2022-11-14
 
 - Fixes for Python 3.11: there are some bugs with `ast.fix_missing_locations` in

--- a/pytest_pyodide/fixture.py
+++ b/pytest_pyodide/fixture.py
@@ -122,9 +122,6 @@ def selenium_standalone_refresh(selenium):
     """
     Experimental standalone fixture which refreshes a page instead of
     instantiating a new webdriver session.
-
-    by setting STANDALONE_REFRESH env variable,
-    selenium_standalone_refresh fixture will override selenium_standalone
     """
     selenium.clean_logs()
 
@@ -135,10 +132,6 @@ def selenium_standalone_refresh(selenium):
     selenium.initialize_pyodide()
     selenium.save_state()
     selenium.restore_state()
-
-
-if os.environ.get("STANDALONE_REFRESH"):
-    selenium_standalone = selenium_standalone_refresh  # type: ignore[assignment] # noqa: F811
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pytest_pyodide.decorator import run_in_pyodide
+
+
+@pytest.mark.parametrize("dummy", [1, 2, 3])
+@run_in_pyodide
+def test_selenium_standalone_refresh(selenium_standalone_refresh, dummy):
+    import pathlib
+
+    p = pathlib.Path("/hello")
+
+    assert not p.exists()
+
+    p.write_text("hello world")
+
+    assert p.is_file()


### PR DESCRIPTION
I introduced `STANDALONE_REFRESH` env variable in order to test `selenium_standalone_refresh` fixture in https://github.com/pyodide/pyodide/pull/2578, but it is not used anymore. This PR removes it.

I added a test for `selenium_standalone_refresh` fixture that runs every time instead.