### PR TITLE
Auto-select python and runner versions

### DIFF
--- a/.github/workflows/filtermatrix.py
+++ b/.github/workflows/filtermatrix.py
@@ -43,6 +43,14 @@ include:
     - os: macos-11
       pyodide-version: 0.21.0
       test-config: {runner: selenium, browser: safari, refresh: 1 }
+      # the following two tests check that the fallback browser behaviour works
+      # okay (this is because ubuntu 22.04 doesn't support getting python 3.10.2)
+    - os: ubuntu-latest
+      pyodide-version: 0.21.0
+      test-config: {runner: selenium, browser: node, browser-version: 18}
+    - os: ubuntu-22.04
+      pyodide-version: 0.21.0
+      test-config: {runner: selenium, browser: node, browser-version: 18}
 """
 )
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,6 +68,7 @@ jobs:
           esac
       - name: Fix runner os
         id: fix_runner_os
+        run: |
           if [ ${{ steps.get_python_version.outputs.python_version }} eq "3.10.2" ]
           then
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Get python version for a particular pyodide version
         id: get_python_version
         run: |
-          case "${{inputs.pyodide-version}}"" in
+          case "${{inputs.pyodide-version}}" in
             *)
               echo "python=3.10.2" >> $GITHUB_OUTPUT
               echo "pythonexec=python310" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,9 +44,10 @@ permissions:
   contents: read
 
 jobs:
+  # separate job needed to setup the correct version of python and github os for pyodide version
   get_versions:
     runs-on: ubuntu-latest
-    name: Setup the correct version of python and github os for pyodide version
+    name: Set python/os version (${{inputs.pyodide-version}},${{inputs.os}})
     outputs:
       os: ${{ steps.fix_runner_os.outputs.os }}
       python: ${{ steps.get_python_version.outputs.python }}
@@ -65,7 +66,7 @@ jobs:
       - name: Fix runner os
         id: fix_runner_os
         run: |
-          if [[ "${{ steps.get_python_version.outputs.python }}" == "3.10.2"  && "${{ inputs.os}}" == ubuntu* && "${{ inputs.os}}" != ubuntu-20.04 ]]
+          if [[ "${{ steps.get_python_version.outputs.python }}" == "3.10.2"  && "${{inputs.os}}" == ubuntu* && "${{inputs.os}}" != ubuntu-20.04 ]]
           then
             echo "Fixing ubuntu version ${{ inputs.os }} to ubuntu-20.04 for python 3.10.2"
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,6 +41,7 @@ on:
         type: string
         default: "latest"
       refresh:
+
         required: false
         type: string
         default: "0"
@@ -48,9 +49,35 @@ permissions:
   contents: read
 
 jobs:
+  get_versions:
+    runs-on: ubuntu-latest
+    name: Setup the correct version of python and github os for pyodide version
+    outputs:
+      os: ${{ steps.fix_runner_os.outputs.os }}
+      python: ${{ steps.get_python_version.outputs.python }}
+      pythonexec: ${{ steps.get_python_version.outputs.pythonexec }}
+    steps:
+      - name: Get python version for a particular pyodide version
+        id: get_python_version
+        run: |
+          case "${{inputs.pyodide-version}}"" in
+            *)
+              echo "python=3.10.2" >> $GITHUB_OUTPUT
+              echo "pythonexec=python310" >> $GITHUB_OUTPUT
+              ;;
+          esac
+      - name: Fix runner os
+        id: fix_runner_os
+          if [ ${{ steps.get_python_version.outputs.python_version }} eq "3.10.2" ]
+          then
+            echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT
+          else
+            echo "os=${{inputs.os}}" >> $GITHUB_OUTPUT
+          fi
   test:
     name: test ${{ inputs.browser }} ( ${{ inputs.runner }},${{ inputs.os }},pyodide:${{ inputs.pyodide-version}})
-    runs-on: ${{ inputs.os }}
+    needs: get_versions
+    runs-on: ${{ needs.get_versions.outputs.os }}
     env:
       DISPLAY: :99
     steps:
@@ -76,7 +103,7 @@ jobs:
           path: ${{ inputs.build-artifact-path }}
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10.2
+          python-version: ${{ needs.get_versions.outputs.python }}
       - name: Install node
         uses: actions/setup-node@v3
         if: ${{ contains(inputs.browser, 'node') || inputs.runner == 'playwright' }}
@@ -96,12 +123,12 @@ jobs:
         run: |
           if [ -n "${{ inputs.runner-version }}" ]
           then
-            python3.10 -m pip install playwright==${{inputs.runner-version}}
+            ${{needs.get_versions.outputs.pythonexec}} -m pip install playwright==${{inputs.runner-version}}
           else
-            python3.10 -m pip install playwright
+            ${{needs.get_versions.outputs.pythonexec}} -m pip install playwright
           fi
           # TODO: install only browsers that are required
-          python3.10 -m playwright install --with-deps
+          ${{needs.get_versions.outputs.pythonexec}} -m playwright install --with-deps
 
       - name: Install firefox
         uses: browser-actions/setup-firefox@latest
@@ -136,20 +163,20 @@ jobs:
         shell: bash -l {0}
         if: inputs.self-build==1
         run: |
-          python3.10 -m pip install -e .
-          python3.10 -m pip install pytest-cov
+          ${{needs.get_versions.outputs.pythonexec}} -m pip install -e .
+          ${{needs.get_versions.outputs.pythonexec}} -m pip install pytest-cov
           # Currently we only install the package for dependencies.
           # We then uninstall it otherwise tests fails due to pytest hook being
           # registered twice.
-          python3.10 -m pip uninstall -y pytest-pyodide
+          ${{needs.get_versions.outputs.pythonexec}} -m pip uninstall -y pytest-pyodide
           which npm && npm install -g npm && npm update
           which npm && npm install node-fetch@2
       - name: Install pytest-pyodide for workflow
         shell: bash -l {0}
         if: inputs.self-build!=1
         run: |
-          python3.10 -m pip install pytest-pyodide
-          python3.10 -m pip install pytest-cov
+          ${{needs.get_versions.outputs.pythonexec}} -m pip install pytest-pyodide
+          ${{needs.get_versions.outputs.pythonexec}} -m pip install pytest-cov
           which npm && npm install -g npm && npm update
           which npm && npm install node-fetch@2
       - name: Get Pyodide from cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,9 +70,9 @@ jobs:
       - name: Fix runner os
         id: fix_runner_os
         run: |
-          if [ "${{ steps.get_python_version.outputs.python }}" = "3.10.2"] && [ "${{ inputs.os}}" = "ubuntu-latest" ]
+          if [[ "${{ steps.get_python_version.outputs.python }}" == "3.10.2"  && "${{ inputs.os}}"==ubuntu* && "${{ inputs.os}}"!=ubuntu-20.04 ]]
           then
-            echo "Fixing ubuntu-latest to ubuntu-20.04 for python 3.10.2"
+            echo "Fixing ubuntu version ${{ inputs.os }} to ubuntu-20.04 for python 3.10.2"
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT
           else
             echo "Using existing OS: ${{inputs.os}} for python ${{ steps.get_python_version.outputs.python }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,12 +69,12 @@ jobs:
       - name: Fix runner os
         id: fix_runner_os
         run: |
-          if [ ${{ steps.get_python_version.outputs.python_version }} eq "3.10.2" -a ${{ inputs.os}} eq "ubuntu-latest" ]
+          if [ ${{ steps.get_python_version.outputs.python }} eq "3.10.2" -a ${{ inputs.os}} eq "ubuntu-latest" ]
           then
             echo "Fixing ubuntu to 20.04 for python 3.10.2"
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT
           else
-            echo "Using existing OS: ${{inputs.os}}"
+            echo "Using existing OS: ${{inputs.os}} for python ${{ steps.get_python_version.outputs.python }}"
             echo "os=${{inputs.os}}" >> $GITHUB_OUTPUT
           fi
   test:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Fix runner os
         id: fix_runner_os
         run: |
-          if [ "${{ steps.get_python_version.outputs.python }}" = "3.10.2"] && [ "${{ inputs.os}}"" = "ubuntu-latest" ]
+          if [ "${{ steps.get_python_version.outputs.python }}" = "3.10.2"] && [ "${{ inputs.os}}" = "ubuntu-latest" ]
           then
             echo "Fixing ubuntu to 20.04 for python 3.10.2"
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,6 +64,7 @@ jobs:
             *)
               echo "python=3.10.2" >> $GITHUB_OUTPUT
               echo "pythonexec=python310" >> $GITHUB_OUTPUT
+              echo "Using python 3.10.2 for pyodide ${{inputs.pyodide-version}}"
               ;;
           esac
       - name: Fix runner os

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Fix runner os
         id: fix_runner_os
         run: |
-          if [[ "${{ steps.get_python_version.outputs.python }}" == "3.10.2"  && "${{ inputs.os}}"==ubuntu* && "${{ inputs.os}}"!=ubuntu-20.04 ]]
+          if [[ "${{ steps.get_python_version.outputs.python }}" == "3.10.2"  && "${{ inputs.os}}" == ubuntu* && "${{ inputs.os}}" != ubuntu-20.04 ]]
           then
             echo "Fixing ubuntu version ${{ inputs.os }} to ubuntu-20.04 for python 3.10.2"
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,14 +69,16 @@ jobs:
       - name: Fix runner os
         id: fix_runner_os
         run: |
-          if [ ${{ steps.get_python_version.outputs.python_version }} eq "3.10.2" ]
+          if [ ${{ steps.get_python_version.outputs.python_version }} eq "3.10.2" -a ${{ inputs.os}} eq "ubuntu-latest" ]
           then
+            echo "Fixing ubuntu to 20.04 for python 3.10.2"
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT
           else
+            echo "Using existing OS: ${{inputs.os}}"
             echo "os=${{inputs.os}}" >> $GITHUB_OUTPUT
           fi
   test:
-    name: test ${{ inputs.browser }} ( ${{ inputs.runner }},${{ inputs.os }},pyodide:${{ inputs.pyodide-version}})
+    name: test ${{ inputs.browser }} ( ${{ inputs.runner }},${{ needs.get_versions.outputs.os }},pyodide:${{ inputs.pyodide-version}})
     needs: get_versions
     runs-on: ${{ needs.get_versions.outputs.os }}
     env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           if [ "${{ steps.get_python_version.outputs.python }}" = "3.10.2"] && [ "${{ inputs.os}}" = "ubuntu-latest" ]
           then
-            echo "Fixing ubuntu to 20.04 for python 3.10.2"
+            echo "Fixing ubuntu-latest to ubuntu-20.04 for python 3.10.2"
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT
           else
             echo "Using existing OS: ${{inputs.os}} for python ${{ steps.get_python_version.outputs.python }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Fix runner os
         id: fix_runner_os
         run: |
-          if [ ${{ steps.get_python_version.outputs.python }} eq "3.10.2" -a ${{ inputs.os}} eq "ubuntu-latest" ]
+          if [ "${{ steps.get_python_version.outputs.python }}" = "3.10.2"] && [ "${{ inputs.os}}"" = "ubuntu-latest" ]
           then
             echo "Fixing ubuntu to 20.04 for python 3.10.2"
             echo "os=ubuntu-20.04" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Add auto-setting of python version and runner version based on pyodide version.
+  [#66](https://github.com/pyodide/pytest-pyodide/pull/66)
+
 - Add support for custom headers in the pytest web server code, by setting
   the `extra_headers` parameter in the `spawn_web_server` function.
   [#39](https://github.com/pyodide/pytest-pyodide/pull/39)


### PR DESCRIPTION
This is a minor update:

a) adds support for changing python version based on pyodide version once pyodide upgrades to 3.11
b) changes ubuntu-latest to ubuntu-20.04 if you try to test something using python 3.10.2 with ubuntu-latest

I know the OS version has been explicitly fixed in pytest github, but it was breaking my CI builds where I'd got ubuntu-latest pointing at this action. Once more than one version of pyodide is supported, we'll need part (a) anyway, and I think part (b) is worth having also, as people shouldn't have to know about which versions of ubuntu are correct for which pyodide version.