### PR TITLE
CI Remove self-build parameter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,6 @@ jobs:
       with:
         build-artifact-name: none
         build-artifact-path: none
-        self-build: 1
 
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Install requirements
         shell: bash -l {0}
-        if: inputs.self-build==1
+        if: ${{ github.event.repo.name == 'pyodide/pytest-pyodide' }}
         run: |
           python3.10 -m pip install -e .
           python3.10 -m pip install pytest-cov
@@ -146,7 +146,7 @@ jobs:
           which npm && npm install node-fetch@2
       - name: Install pytest-pyodide for workflow
         shell: bash -l {0}
-        if: inputs.self-build!=1
+        if: ${{ github.event.repo.name != 'pyodide/pytest-pyodide' }}
         run: |
           python3.10 -m pip install pytest-pyodide
           python3.10 -m pip install pytest-cov
@@ -168,6 +168,6 @@ jobs:
             --rt ${{ inputs.browser }}
 
       - uses: codecov/codecov-action@v3
-        if: ${{ inputs.self-build==1 && (github.event.repo.name == 'pyodide/pytest-pyodide' || github.event_name == 'pull_request') }}
+        if: ${{ (github.event.repo.name == 'pyodide/pytest-pyodide' || github.event_name == 'pull_request') }}
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -132,9 +132,13 @@ jobs:
           # Only one Safari browser instance can be active at any given time
           echo "STANDALONE_REFRESH=${{ inputs.refresh }}" >> $GITHUB_ENV
 
+      - name: Parse repository name
+        id: repo-name
+        run: echo "repo_name=${GITHUB_REPOSITORY#*/}" >> $GITHUB_OUTPUT
+
       - name: Install requirements
         shell: bash -l {0}
-        if: ${{ github.event.repo.name == 'pyodide/pytest-pyodide' }}
+        if: ${{ steps.repo-name.outputs.repo_name == 'pytest-pyodide' }}
         run: |
           python3.10 -m pip install -e .
           python3.10 -m pip install pytest-cov
@@ -146,7 +150,7 @@ jobs:
           which npm && npm install node-fetch@2
       - name: Install pytest-pyodide for workflow
         shell: bash -l {0}
-        if: ${{ github.event.repo.name != 'pyodide/pytest-pyodide' }}
+        if: ${{ steps.repo-name.outputs.repo_name != 'pytest-pyodide' }}
         run: |
           python3.10 -m pip install pytest-pyodide
           python3.10 -m pip install pytest-cov

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,6 +61,7 @@ jobs:
         with:
           path: pyodide-dist
           key: pyodide-${{ inputs.pyodide-version }}-${{ hashFiles('.github/**/*.yaml') }}
+
       - name: Download Pyodide
         shell: bash -l {0}
         if: steps.cache-pyodide.outputs.cache-hit != 'true'
@@ -68,8 +69,13 @@ jobs:
           wget -q https://github.com/pyodide/pyodide/releases/download/${{ inputs.pyodide-version }}/pyodide-build-${{ inputs.pyodide-version }}.tar.bz2
           tar xjf pyodide-build-${{ inputs.pyodide-version }}.tar.bz2
           mv pyodide pyodide-dist/
+
+      - name: Parse repository name
+        id: repo-name
+        run: echo "repo_name=${GITHUB_REPOSITORY#*/}" >> $GITHUB_OUTPUT
+
       - name: Download build artifacts from calling package
-        if: inputs.self-build!=1
+        if: ${{ steps.repo-name.outputs.repo_name != 'pytest-pyodide' }}
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.build-artifact-name }}
@@ -131,10 +137,6 @@ jobs:
           sudo safaridriver --enable
           # Only one Safari browser instance can be active at any given time
           echo "STANDALONE_REFRESH=${{ inputs.refresh }}" >> $GITHUB_ENV
-
-      - name: Parse repository name
-        id: repo-name
-        run: echo "repo_name=${GITHUB_REPOSITORY#*/}" >> $GITHUB_OUTPUT
 
       - name: Install requirements
         shell: bash -l {0}

--- a/.github/workflows/testall.yaml
+++ b/.github/workflows/testall.yaml
@@ -9,9 +9,6 @@ on:
       build-artifact-path:
         required: true
         type: string
-      self-build:
-        required: false
-        type: number
       pyodide-versions:
         required: false
         type: string
@@ -59,7 +56,6 @@ jobs:
     with:
       build-artifact-name: ${{ inputs.build-artifact-name }}
       build-artifact-path: ${{ inputs.build-artifact-path }}
-      self-build: ${{ inputs.self-build }}
       pyodide-version: ${{ matrix.pyodide-version }}
       runner: ${{ matrix.test-config.runner }}
       browser: ${{ matrix.test-config.browser }}


### PR DESCRIPTION
Remove `self-build` parameter which check if the GHA is called internally or from outside.
Instead, check the repository name and if it is `pytest-pyodide` (pyodide/pytest-pyodide or forks).