### PR TITLE
Remove self build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,6 @@ jobs:
       with:
         build-artifact-name: none
         build-artifact-path: none
-        self-build: 1
 
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -127,7 +127,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python3.10 -m pip install pytest-cov
-          if [ -d "pytest-pyodide" ]; then
+          if [ -d "pytest_pyodide" ]; then
             # Currently we only install the package for dependencies.
             # We then uninstall it otherwise tests fails due to pytest hook being
             # registered twice.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -159,4 +159,4 @@ jobs:
       - uses: codecov/codecov-action@v3
         if: ${{ steps.check_coverage.outputs.files_exists }}
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,9 +9,6 @@ on:
       build-artifact-path:
         required: true
         type: string
-      self-build:
-        required: false
-        type: number
       pyodide-version:
         required: false
         type: string
@@ -65,7 +62,7 @@ jobs:
           tar xjf pyodide-build-${{ inputs.pyodide-version }}.tar.bz2
           mv pyodide pyodide-dist/
       - name: Download build artifacts from calling package
-        if: inputs.self-build!=1
+        if: ${{ inputs.build-artifact-name != 'none' }}
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.build-artifact-name }}
@@ -126,24 +123,19 @@ jobs:
         run: |
           sudo safaridriver --enable
 
-      - name: Install requirements
+      - name: Install pytest-pyodide
         shell: bash -l {0}
-        if: inputs.self-build==1
         run: |
-          python3.10 -m pip install -e .
           python3.10 -m pip install pytest-cov
-          # Currently we only install the package for dependencies.
-          # We then uninstall it otherwise tests fails due to pytest hook being
-          # registered twice.
-          python3.10 -m pip uninstall -y pytest-pyodide
-          which npm && npm install -g npm && npm update
-          which npm && npm install node-fetch@2
-      - name: Install pytest-pyodide for workflow
-        shell: bash -l {0}
-        if: inputs.self-build!=1
-        run: |
-          python3.10 -m pip install pytest-pyodide
-          python3.10 -m pip install pytest-cov
+          if [ -d "pytest-pyodide" ]; then
+            # Currently we only install the package for dependencies.
+            # We then uninstall it otherwise tests fails due to pytest hook being
+            # registered twice.
+              python3.10 -m pip install -e .
+              python3.10 -m pip uninstall -y pytest-pyodide
+          else
+              python3.10 -m pip install pytest-pyodide
+          fi
           which npm && npm install -g npm && npm update
           which npm && npm install node-fetch@2
       - name: Get Pyodide from cache
@@ -151,7 +143,6 @@ jobs:
         with:
           path: pyodide-dist
           key: pyodide-${{ inputs.pyodide-version }}-${{ hashFiles('.github/**/*.yaml') }}
-
       - name: Run tests
         shell: bash -l {0}
         run: |
@@ -160,8 +151,12 @@ jobs:
             --dist-dir=./pyodide-dist/ \
             --runner=${{ inputs.runner }} \
             --rt ${{ inputs.browser }}
-
+      - name: Check for coverage file
+        id: check_coverage
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "coverage.xml"
       - uses: codecov/codecov-action@v3
-        if: ${{ inputs.self-build==1 && (github.event.repo.name == 'pyodide/pytest-pyodide' || github.event_name == 'pull_request') }}
+        if: ${{ steps.check_coverage.outputs.files_exists }}
         with:
           fail_ci_if_error: true

--- a/.github/workflows/testall.yaml
+++ b/.github/workflows/testall.yaml
@@ -9,9 +9,6 @@ on:
       build-artifact-path:
         required: true
         type: string
-      self-build:
-        required: false
-        type: number
       pyodide-versions:
         required: false
         type: string
@@ -59,7 +56,6 @@ jobs:
     with:
       build-artifact-name: ${{ inputs.build-artifact-name }}
       build-artifact-path: ${{ inputs.build-artifact-path }}
-      self-build: ${{ inputs.self-build }}
       pyodide-version: ${{ matrix.pyodide-version }}
       runner: ${{ matrix.test-config.runner }}
       browser: ${{ matrix.test-config.browser }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,4 +48,5 @@ asyncio_mode = strict
 addopts =
     --tb=short
     --doctest-modules
+    --cov=pytest_pyodide --cov-report xml
 testpaths = tests


### PR DESCRIPTION
I think this is how one should get rid of the self-build parameter (see https://github.com/pyodide/pytest-pyodide/pull/67 )

There's one check which is if the package includes pytest-pyodide it uninstalls the pip version, other than that it does pretty much the same for pytest-pyodide and other projects.

