### PR TITLE
Add tests for plugin commandline options

### DIFF
--- a/.github/workflows/filtermatrix.py
+++ b/.github/workflows/filtermatrix.py
@@ -26,11 +26,6 @@ test-config: [
     {runner: selenium, browser: node, browser-version: 16},
     {runner: selenium, browser: node, browser-version: 18},
     {runner: selenium, browser: firefox-no-host, browser-version: latest, driver-version: latest },
-    {
-    runner: selenium, browser: chrome firefox,
-    browser-version: latest, browser-version: latest,
-    browser-version: latest, browser-version: latest,
-    },
     {runner: selenium, browser: host},
     # playwright browser versions are pinned to playwright version
     {runner: playwright, browser: firefox, runner-version: 1.22.0, driver-version: 18},

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 pytest_plugins = [
     "pytest_pyodide.hook",
     "pytest_pyodide.fixture",
+    "pytester",
 ]

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -8,8 +8,8 @@ def test_dist_dir(pytester):
     pytester.makepyfile(
         f"""
         import pytest
-        def test_dist_dir(request):
-            assert request.config.option.getoption("--dist-dir") == {dist_dir!r}
+        def test_option(request):
+            assert request.config.getoption("--dist-dir") == {dist_dir!r}
         """
     )
 
@@ -22,8 +22,8 @@ def test_runner(pytester, runner):
     pytester.makepyfile(
         f"""
         import pytest
-        def test_dist_dir(request):
-            assert request.config.option.getoption("--runner") == {runner!r}
+        def test_option(request):
+            assert request.config.getoption("--runner") == {runner!r}
         """
     )
 
@@ -38,10 +38,56 @@ def test_invalid_runner(pytester):
     pytester.makepyfile(
         f"""
         import pytest
-        def test_dist_dir(request):
-            assert request.config.option.getoption("--runner") == {runner!r}
+        def test_option(request):
+            assert request.config.getoption("--runner") == {runner!r}
         """
     )
 
     result = pytester.runpytest("--runner", runner)
+    result.assert_outcomes(failed=1)
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    [
+        "chrome",
+        "firefox",
+        "safari",
+        "node",
+        "chrome-no-host",
+        "firefox-no-host",
+        "safari-no-host",
+        "node-no-host",
+        "firefox chrome",
+    ],
+)
+def test_runtime(pytester, runtime):
+
+    runtimes = runtime.split()
+
+    pytester.makepyfile(
+        f"""
+        import pytest
+        def test_option(request):
+            assert request.config.getoption("--runtime") == {runtimes!r}
+        """
+    )
+
+    result = pytester.runpytest("--runtime", *runtimes)
+    result.assert_outcomes(passed=1)
+
+
+def test_invalid_runtime(pytester):
+
+    runtimes = ["blah"]
+
+    pytester.makepyfile(
+        f"""
+        import pytest
+        def test_option(request):
+            assert request.config.getoption("--runtime") == {runtimes!r}
+        """
+    )
+
+    result = pytester.runpytest("--runtime", *runtimes)
     result.assert_outcomes(failed=1)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -48,7 +48,7 @@ def test_invalid_runner(pytester):
 
 
 @pytest.mark.parametrize(
-    "runtime",
+    "_runtime",
     [
         "chrome",
         "firefox",
@@ -61,9 +61,9 @@ def test_invalid_runner(pytester):
         "firefox chrome",
     ],
 )
-def test_runtime(pytester, runtime):
+def test_runtime(pytester, _runtime):
 
-    runtimes = runtime.split()
+    runtimes = _runtime.split()
 
     pytester.makepyfile(
         f"""

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,13 @@
+def test_dist_dir(pytester):
+
+    dist_dir = "dist"
+
+    pytester.makepyfile(
+        f"""
+        def test_dist_dir():
+            assert pytest.pyodide_dist_dir == {dist_dir!r}
+        """
+    )
+
+    result = pytester.runpytest("--dist-dir", dist_dir)
+    result.assert_outcomes(passed=1)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,13 +1,47 @@
+import pytest
+
+
 def test_dist_dir(pytester):
 
     dist_dir = "dist"
 
     pytester.makepyfile(
         f"""
-        def test_dist_dir():
-            assert pytest.pyodide_dist_dir == {dist_dir!r}
+        import pytest
+        def test_dist_dir(request):
+            assert request.config.option.getoption("--dist-dir") == {dist_dir!r}
         """
     )
 
     result = pytester.runpytest("--dist-dir", dist_dir)
     result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize("runner", ["selenium", "playwright"])
+def test_runner(pytester, runner):
+    pytester.makepyfile(
+        f"""
+        import pytest
+        def test_dist_dir(request):
+            assert request.config.option.getoption("--runner") == {runner!r}
+        """
+    )
+
+    result = pytester.runpytest("--runner", runner)
+    result.assert_outcomes(passed=1)
+
+
+def test_invalid_runner(pytester):
+
+    runner = "blah"
+
+    pytester.makepyfile(
+        f"""
+        import pytest
+        def test_dist_dir(request):
+            assert request.config.option.getoption("--runner") == {runner!r}
+        """
+    )
+
+    result = pytester.runpytest("--runner", runner)
+    result.assert_outcomes(failed=1)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -9,7 +9,7 @@ def test_dist_dir(pytester):
         f"""
         import pytest
         def test_option(request):
-            assert request.config.getoption("--dist-dir") == {dist_dir!r}
+            assert str(request.config.getoption("--dist-dir", "")) == {dist_dir!r}
         """
     )
 
@@ -44,7 +44,9 @@ def test_invalid_runner(pytester):
     )
 
     result = pytester.runpytest("--runner", runner)
-    result.assert_outcomes(failed=1)
+
+    # pytest: error argument --runner: invalid choice ...
+    assert result.ret == 4
 
 
 @pytest.mark.parametrize(
@@ -54,10 +56,6 @@ def test_invalid_runner(pytester):
         "firefox",
         "safari",
         "node",
-        "chrome-no-host",
-        "firefox-no-host",
-        "safari-no-host",
-        "node-no-host",
         "firefox chrome",
     ],
 )
@@ -75,19 +73,3 @@ def test_runtime(pytester, _runtime):
 
     result = pytester.runpytest("--runtime", *runtimes)
     result.assert_outcomes(passed=1)
-
-
-def test_invalid_runtime(pytester):
-
-    runtimes = ["blah"]
-
-    pytester.makepyfile(
-        f"""
-        import pytest
-        def test_option(request):
-            assert request.config.getoption("--runtime") == {runtimes!r}
-        """
-    )
-
-    result = pytester.runpytest("--runtime", *runtimes)
-    result.assert_outcomes(failed=1)


### PR DESCRIPTION
This adds tests for plugin cmdline options `--dist-dir`, `--runner`, `--runtime`, while removing a test-config that makes #59 fail.