### PR TITLE
make codecov wait for ci to finish before reporting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,4 +3,4 @@ codecov:
   branch: main
   require_ci_to_pass: false
   notify:
-    wait_for_ci: false
+    wait_for_ci: true


### PR DESCRIPTION
Otherwise when you do the big mega-build codecov reports low numbers because e.g. it reports back before playwright builds have finished.

I think this is pretty straightforward, but I wasn't sure if there was a reason this setting was turned on?