### PR TITLE
Version 0.50

### DIFF
--- a/.github/workflows/filtermatrix.py
+++ b/.github/workflows/filtermatrix.py
@@ -11,7 +11,7 @@ import yaml
 # the configs below
 pyodide_versions = sys.argv[1]
 if pyodide_versions == "*":
-    pyodide_versions = "[0.21.0a3,0.21.0]"
+    pyodide_versions = "[0.22.0,0.21.0]"
 
 matrix = yaml.safe_load(
     """

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.24.0] - 2023-01-03
+## [0.24.0] - 2023-01-05
 
 - Add auto-setting of python version and runner version based on pyodide version.
   [#66](https://github.com/pyodide/pytest-pyodide/pull/66)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [0.24.0] - 2023-01-03
 
 - Add auto-setting of python version and runner version based on pyodide version.
   [#66](https://github.com/pyodide/pytest-pyodide/pull/66)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.24.0] - 2023-01-05
+## [0.50.0] - 2023-01-05
 
 - Add auto-setting of python version and runner version based on pyodide version.
   [#66](https://github.com/pyodide/pytest-pyodide/pull/66)

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Following versions of pytest-pyodide and Pyodide are tested in CI. Other version
 | pytest-pyodide | Tested Pyodide versions |
 |----------------|-------------------------|
 | 0.23.*         | 0.21.0                  |
-| 0.24.0         | 0.21.0, 0.22.0          |
+| 0.50.0         | 0.21.0, 0.22.0          |
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -282,6 +282,18 @@ specific browsers.
 
 See [`examples`](./examples).
 
+
+## Compatible Pyodide versions
+
+
+Following versions of pytest-pyodide and Pyodide are tested in CI. Other versions may work, however with no guarantee.
+
+| pytest-pyodide | Tested Pyodide versions |
+|----------------|-------------------------|
+| 0.23.*         | 0.21.0                  |
+| 0.24.0         | 0.21.0, 0.22.0          |
+
+
 ## License
 
 pytest-pyodide uses the [Mozilla Public License Version


### PR DESCRIPTION
It would probably be good to make a new release. 
Closes #50 

I added the compatibility table between pytest-pyodide and Pyodide to the Readme and updated CI to test Pyodide 0.22.0

I would still be more comfortable if the version of this package wasn't closely following Pyodide version, while being completely unrelated. At the same time, the only thing we could do to avoid it is to make 1.0.0 release, which is probably still a bit early.

cc @ryanking13 @joemarshall 