### PR TITLE
CI Use ruff + remove GHA lint job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,11 +35,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-  lint:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        with:
-          python-version: 3.10.2
-      - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-exclude: (^.*patches|.*\.cgi$|^packages/micropip/src/micropip/externals|^benchmark/benchmarks$)
 default_language_version:
   python: "3.10"
 repos:
@@ -16,34 +15,16 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
-  - repo: https://github.com/PyCQA/isort
-    rev: "5.12.0"
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.254"
     hooks:
-      - id: isort
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: "v3.3.1"
-    hooks:
-      - id: pyupgrade
-        args: ["--py310-plus"]
-
-  - repo: https://github.com/hadialqattan/pycln
-    rev: "v2.1.3"
-    hooks:
-      - id: pycln
-        args: [--config=pyproject.toml]
-        stages: [manual]
+      - id: ruff
+        args: [--fix]
 
   - repo: https://github.com/psf/black
-    rev: "23.3.0"
+    rev: "23.1.0"
     hooks:
       - id: black
-
-  - repo: https://github.com/pycqa/flake8
-    rev: "6.0.0"
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.1.1"
@@ -70,3 +51,6 @@ repos:
       - id: codespell
         args: ["-L", "te,slowy,aray,ba,nd,classs,crate,feld,lits"]
         exclude: ^benchmark/benchmarks/pystone_benchmarks/pystone\.py$
+
+ci:
+  autoupdate_schedule: "quarterly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,15 +23,37 @@ strict_equality = true
 ignore_missing_imports = true
 # this
 
-[tool.pycln]
-all = true
+[tool.ruff]
+select = [
+  "B0",     # bugbear (all B0* checks enabled by default)
+  "B904",   # bugbear (Within an except clause, raise exceptions with raise ... from err)
+  "B905",   # bugbear (zip() without an explicit strict= parameter set.)
+  "C9",     # mccabe complexity
+  "E",      # pycodestyles
+  "W",      # pycodestyles
+  "F",      # pyflakes
+  "I",      # isort
+  "PGH",    # pygrep-hooks
+  "PLC",    # pylint conventions
+  "PLE",    # pylint errors
+  "UP",     # pyupgrade
+]
+ignore = ["E402", "E501", "E731", "E741"]
+# line-length = 219  # E501: Recommended goal is 88 to match black
+target-version = "py310"
 
-[tool.isort]
-profile = "black"
-known_first_party = [
+[tool.ruff.isort]
+known-first-party = [
   "pyodide",
   "pyodide_js",
   "micropip",
   "pyodide_build",
   "_pyodide",
+  "js",
 ]
+known-third-party = [
+  "build",
+]
+
+[tool.ruff.mccabe]
+max-complexity = 31  # C901: Recommended goal is 10

--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -377,7 +377,7 @@ class run_in_pyodide:
                 continue
 
             # We also want the function definition for the current test
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 continue
 
             if node.lineno < func_line_no:

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -219,7 +219,7 @@ def pytest_runtest_setup(item):
     if item.config.option.run_in_pyodide:
         if not hasattr(item, "fixturenames"):
             return
-        if pytest.pyodide_runtimes and "runtime" in item.fixturenames:  # type: ignore[truthy-bool]
+        if pytest.pyodide_runtimes and "runtime" in item.fixturenames:
             pytest.skip(reason="pyodide specific test, can't run in pyodide")
         else:
             # Pass this test to pyodide runner
@@ -252,9 +252,9 @@ def pytest_runtest_setup(item):
         if not hasattr(item, "fixturenames"):
             # Some items like DoctestItem have no fixture
             return
-        if not pytest.pyodide_runtimes and "runtime" in item.fixturenames:  # type: ignore[truthy-bool]
+        if not pytest.pyodide_runtimes and "runtime" in item.fixturenames:
             pytest.skip(reason="Non-host test")
-        elif not pytest.pyodide_run_host_test and "runtime" not in item.fixturenames:  # type: ignore[truthy-bool]
+        elif not pytest.pyodide_run_host_test and "runtime" not in item.fixturenames:
             pytest.skip("Host test")
 
 

--- a/pytest_pyodide/server.py
+++ b/pytest_pyodide/server.py
@@ -82,7 +82,7 @@ def run_web_server(q, log_filepath, dist_dir, extra_headers, handler_cls):
 
     with socketserver.TCPServer(("", 0), handler_cls) as httpd:
         host, port = httpd.server_address
-        print(f"Starting webserver at http://{host}:{port}")
+        print(f"Starting webserver at http://{host}:{port}")  # type: ignore[str-bytes-safe]
         httpd.server_name = "test-server"  # type: ignore[attr-defined]
         httpd.server_port = port  # type: ignore[attr-defined]
         q.put(port)

--- a/pytest_pyodide/server.py
+++ b/pytest_pyodide/server.py
@@ -95,5 +95,5 @@ def run_web_server(q, log_filepath, dist_dir, extra_headers, handler_cls):
             except queue.Empty:
                 pass
 
-        httpd.service_actions = service_actions  # type: ignore[assignment]
+        httpd.service_actions = service_actions  # type: ignore[method-assign]
         httpd.serve_forever()


### PR DESCRIPTION
Replace iosrt, pycln, pyupgrade, and flake8 with ruff as we do in other repositories.

This PR also removes GHA linter job, in favor of pre-commit.ci.