### PR TITLE
Remove executable_path from selenium driver construction

### DIFF
--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -415,13 +415,14 @@ class SeleniumFirefoxRunner(_SeleniumBaseRunner):
     def get_driver(self):
         from selenium.webdriver import Firefox
         from selenium.webdriver.firefox.options import Options
+        from selenium.webdriver.firefox.service import Service
 
         options = Options()
         options.add_argument("--headless")
         for flag in FIREFOX_FLAGS:
             options.add_argument(flag)
 
-        return Firefox(executable_path="geckodriver", options=options)
+        return Firefox(service=Service("geckodriver"), options=options)
 
 
 class SeleniumChromeRunner(_SeleniumBaseRunner):


### PR DESCRIPTION
executable_path has been deprecated since Selenium v4.0.0b1 and is removed in v4.10. Remove it.
https://github.com/SeleniumHQ/selenium/blob/d6acda7c0254f9681574bf4078ff2001705bf940/py/CHANGES#L101