### PR TITLE
ENH Add rename_fixture and standalone decorators

### DIFF
--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -170,6 +170,21 @@ def pytest_generate_tests(metafunc: Any) -> None:
         metafunc.parametrize("runtime", pytest.pyodide_runtimes, scope="module")
 
 
+STANDALONE_FIXTURES = [
+    "selenium_standalone",
+    "selenium_standalone_noload",
+    "selenium_webworker_standalone",
+]
+
+
+def _has_standalone_fixture(item):
+    for fixture in item._request.fixturenames:
+        if fixture in STANDALONE_FIXTURES:
+            return True
+
+    return False
+
+
 def pytest_collection_modifyitems(items: list[Any]) -> None:
     # if we are running tests in pyodide, then run all tests for each runtime
     if len(items) > 0 and items[0].config.option.run_in_pyodide:
@@ -186,28 +201,14 @@ def pytest_collection_modifyitems(items: list[Any]) -> None:
     # Since Safari doesn't support more than one simultaneous session, we run all
     # selenium_standalone Safari tests first. We preserve the order of other
     # tests.
-
     OFFSET = 10000
-
     counter = [0]
-    standalone_fixtures = [
-        "selenium_standalone",
-        "selenium_standalone_noload",
-        "selenium_webworker_standalone",
-    ]
-
-    def _has_standalone_fixture(fixturenames):
-        for fixture in fixturenames:
-            if fixture in standalone_fixtures:
-                return True
-
-        return False
 
     def _get_item_position(item):
         counter[0] += 1
         if any(
             [re.match(r"^safari[\-$]?", el) for el in item.keywords._markers.keys()]
-        ) and _has_standalone_fixture(item._request.fixturenames):
+        ) and _has_standalone_fixture(item):
             return counter[0] - OFFSET
         return counter[0]
 

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pytest_pyodide.decorator import run_in_pyodide
+from pytest_pyodide.fixture import rename_fixture
 
 
 @pytest.mark.parametrize("dummy", [1, 2, 3])
@@ -24,3 +25,29 @@ def test_playwright_browsers(playwright_browsers, request):
     runtimes = pytest.pyodide_runtimes
 
     assert set(playwright_browsers.keys()) == set(runtimes)
+
+
+@rename_fixture("myfixture", "myfixture_variant")
+def myfunc(a, myfixture):
+    return [a, myfixture]
+
+
+def test_rename_fixture1():
+    assert myfunc(2, 3) == [2, 3]
+    assert myfunc(2, myfixture_variant=3) == [2, 3]
+    assert myfunc(a=2, myfixture_variant=3) == [2, 3]
+
+
+@pytest.fixture
+def myfixture():
+    yield 27
+
+
+@pytest.fixture
+def myfixture_variant():
+    yield 99
+
+
+@rename_fixture("myfixture", "myfixture_variant")
+def test_rename_fixture2(myfixture):
+    assert myfixture == 99


### PR DESCRIPTION
We use a bunch of different selenium variants but for the most part they are drop-in replacements for each other. For instance, when using `selenium_standalone`, we always just say `selenium = selenium_standalone` at the top of the function. I think it's clearer if we use a decorator to rename the fixture.