### PR TITLE
Use pyodide-actions@v1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -112,12 +112,12 @@ jobs:
           # TODO: install only browsers that are required
           ${{needs.get_versions.outputs.pythonexec}} -m playwright install --with-deps
 
-      - uses: pyodide/pyodide-actions/download-pyodide@v1.1.0
+      - uses: pyodide/pyodide-actions/download-pyodide@v1
         with:
           version: ${{ inputs.pyodide-version }}
           to: pyodide-dist
 
-      - uses: pyodide/pyodide-actions/install-browser@v1.1.0
+      - uses: pyodide/pyodide-actions/install-browser@v1
         with:
           runner: ${{ inputs.runner }}
           browser: ${{ inputs.browser }}


### PR DESCRIPTION
Use pyodide-actions@v1 so that an update in pyodide-actions can be applied without modification in pytest-pyodide.

It is interesting that [the recommended way of versioning github actions is moving tags](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md)... so we need to force push to v1 tag whenever we make an update to pyodide-actions.