### PR TITLE
Fix selenium can't find FireFox driver

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -125,6 +125,13 @@ jobs:
           driver-version: ${{ inputs.driver-version }}
           playwright-version: ${{ inputs.runner-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Check install
+        shell: bash -l {0}
+        if: ${{ inputs.browser == 'firefox' }}
+        run: |
+          which firefox
+          which geckodriver
 
       - name: Download build artifacts from calling package
         if: ${{ inputs.build-artifact-name != 'none' }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -125,13 +125,6 @@ jobs:
           driver-version: ${{ inputs.driver-version }}
           playwright-version: ${{ inputs.runner-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Check install
-        shell: bash -l {0}
-        if: ${{ inputs.browser == 'firefox' }}
-        run: |
-          which firefox
-          which geckodriver
 
       - name: Download build artifacts from calling package
         if: ${{ inputs.build-artifact-name != 'none' }}

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -427,7 +427,7 @@ class SeleniumFirefoxRunner(_SeleniumBaseRunner):
         for flag in FIREFOX_FLAGS:
             options.add_argument(flag)
 
-        return Firefox(service=Service("geckodriver"), options=options)
+        return Firefox(service=Service(), options=options)
 
 
 class SeleniumChromeRunner(_SeleniumBaseRunner):


### PR DESCRIPTION
This fixes a regression introduced in Selenium 4.11.

From Selenium 4.11, if we pass a binary name to `Service`, it will not search the binary from PATH, but it will use it as a relative path and search the binary from cwd instead (I think it is a bug).

This PR fixes it by not passing the binary name, so that letting selenium locate the binary from PATH.

Related PR: https://github.com/SeleniumHQ/selenium/pull/12356