### PR TITLE
Prevent from overwriting global configurations

### DIFF
--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -92,9 +92,15 @@ def pytest_configure(config):
     )
 
     run_host, runtimes = _filter_runtimes(config.option.runtime)
-    pytest.pyodide_run_host_test = run_host
-    pytest.pyodide_runtimes = runtimes
-    pytest.pyodide_dist_dir = config.getoption("--dist-dir")
+
+    # using `pytester` fixture seems to call this hook again with different options
+    # so this is a workaround to avoid overwriting the values
+    if not hasattr(pytest, "pyodide_run_host_test"):
+        pytest.pyodide_run_host_test = run_host
+    if not hasattr(pytest, "pyodide_runtimes"):
+        pytest.pyodide_runtimes = runtimes
+    if not hasattr(pytest, "pyodide_dist_dir"):
+        pytest.pyodide_dist_dir = config.getoption("--dist-dir")
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pytest_pyodide.hook import _filter_runtimes
 
 
@@ -55,10 +56,10 @@ def test_invalid_runner(pytester):
     ],
 )
 def test_invalid_runtime(pytester, _runtime):
-    runtimes = _runtime.split(",")
+    _runtime.split(",")
 
     pytester.makepyfile(
-        f"""
+        """
         import pytest
         def test_option():
             assert True
@@ -85,4 +86,3 @@ def test_invalid_runtime(pytester, _runtime):
 )
 def test_filter_runtimes(_runtime, expected):
     _filter_runtimes(_runtime) == expected
-    

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_pyodide.hook import _filter_runtimes
 
 
 def test_dist_dir(pytester):
@@ -50,31 +51,6 @@ def test_invalid_runner(pytester):
 @pytest.mark.parametrize(
     "_runtime",
     [
-        "chrome",
-        "firefox",
-        "safari",
-        "node",
-        "firefox,chrome",
-    ],
-)
-def test_runtime(pytester, _runtime):
-    runtimes = _runtime.split(",")
-
-    pytester.makepyfile(
-        f"""
-        import pytest
-        def test_option():
-            assert pytest.pyodide_runtimes == set({runtimes!r})
-        """
-    )
-
-    result = pytester.runpytest("--runtime", _runtime)
-    result.assert_outcomes(passed=1)
-
-
-@pytest.mark.parametrize(
-    "_runtime",
-    [
         "invalid",
     ],
 )
@@ -85,7 +61,7 @@ def test_invalid_runtime(pytester, _runtime):
         f"""
         import pytest
         def test_option():
-            assert pytest.pyodide_runtimes == set({runtimes!r})
+            assert True
         """
     )
 
@@ -93,3 +69,20 @@ def test_invalid_runtime(pytester, _runtime):
     with pytest.raises(ValueError, match="Pytest terminal summary report not found"):
         result = pytester.runpytest("--runtime", _runtime)
         result.assert_outcomes(errors=1)
+
+
+@pytest.mark.parametrize(
+    "_runtime,expected",
+    [
+        ("chrome", (True, {"chrome"})),
+        ("firefox", (True, {"firefox"})),
+        ("node", (True, {"node"})),
+        ("chrome,firefox", (True, {"chrome", "firefox"})),
+        ("chrome-no-host,firefox", (False, {"chrome", "firefox"})),
+        ("host", (True, set())),
+        ("chrome-no-host,host", (True, {"chrome"})),
+    ],
+)
+def test_filter_runtimes(_runtime, expected):
+    _filter_runtimes(_runtime) == expected
+    


### PR DESCRIPTION
This fixes a test failure that started to occur after #101.

```
! _pytest.outcomes.Exit: playwright failed to launch
```

The cause of the problem was that the combination of the `pytester` fixture and the `pytest_configure` hook is not very good.
We use `pytest_configure` to manage global settings, but this function is called again when we run sub-tests using pytester, resulting in new global settings being overwritten.

So I added a check to prevent overwriting global settings once it is set.
