### PR TITLE
Add support for `pytest.skip` etc inside of `@run_in_pyodide`

### DIFF
--- a/pytest_pyodide/_decorator_in_pyodide.py
+++ b/pytest_pyodide/_decorator_in_pyodide.py
@@ -65,7 +65,10 @@ class Pickler(pickle.Pickler):
             from _pytest.outcomes import OutcomeException
 
             if isclass(obj) and issubclass(obj, OutcomeException):
-                obj.__module__ = "_pytest.outcomes"
+                # To shorten the repr, pytest sets the __module__ of these
+                # classes to builtins. This breaks pickling. Restore the correct
+                # value.
+                obj.__module__ = OutcomeException.__module__
         except ImportError:
             pass
         return NotImplemented

--- a/pytest_pyodide/_decorator_in_pyodide.py
+++ b/pytest_pyodide/_decorator_in_pyodide.py
@@ -18,6 +18,7 @@ https://github.com/pyodide/pytest-pyodide/issues/43
 
 import pickle
 from base64 import b64decode, b64encode
+from inspect import isclass
 from io import BytesIO
 from typing import Any
 
@@ -58,6 +59,16 @@ class Pickler(pickle.Pickler):
             return None
         pyodide_js._module._Py_IncRef(obj.ptr)
         return ("PyodideHandle", obj.ptr)
+
+    def reducer_override(self, obj):
+        try:
+            from _pytest.outcomes import OutcomeException
+
+            if isclass(obj) and issubclass(obj, OutcomeException):
+                obj.__module__ = "_pytest.outcomes"
+        except ImportError:
+            pass
+        return NotImplemented
 
 
 class Unpickler(pickle.Unpickler):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -282,3 +282,17 @@ def test_selenium_handle(selenium):
     check_refcount(selenium, 4)
     del handle
     check_refcount(selenium, 3)
+
+
+def test_pytest_dot_skip(selenium):
+    """Check that pytest.skip, etc will work inside @run_in_pyodide"""
+
+    @run_in_pyodide(_force_assert_rewrites=True)
+    def helper(selenium, meth):
+        import pytest
+
+        getattr(pytest, meth)("blah")
+
+    for meth in ["skip", "fail", "xfail"]:
+        with pytest.raises(getattr(pytest, meth).Exception):
+            helper(selenium, meth)


### PR DESCRIPTION
Fixes a shortcoming encountered by @szabolcsdombi in https://github.com/pyodide/pyodide/pull/4208.
pytest sets `__module__` to `builtins`. This puts back the correct value.