### PR TITLE
Embed JS files for testing webworker into pytest-pyodide wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - BREAKING: dropped support for Node < 18.
   [#113](https://github.com/pyodide/pytest-pyodide/pull/113)
 
+- Added webworker test template files into the package.
+  [#112](https://github.com/pyodide/pytest-pyodide/pull/112)
+
 ## [0.53.1] - 2023-10-10
 
 - Removed the ctypes dependency so it can be used with Python builds with

--- a/pytest_pyodide/_templates/module_webworker_dev.js
+++ b/pytest_pyodide/_templates/module_webworker_dev.js
@@ -1,0 +1,26 @@
+import { loadPyodide } from "./pyodide.mjs";
+
+onmessage = async function (e) {
+  try {
+    const data = e.data;
+    for (let key of Object.keys(data)) {
+      if (key !== "python") {
+        // Keys other than python must be arguments for the python script.
+        // Set them on self, so that `from js import key` works.
+        self[key] = data[key];
+      }
+    }
+
+    if (!loadPyodide.inProgress) {
+      self.pyodide = await loadPyodide();
+    }
+    await self.pyodide.loadPackagesFromImports(data.python);
+    let results = await self.pyodide.runPythonAsync(data.python);
+    self.postMessage({ results });
+  } catch (e) {
+    // if you prefer messages with the error
+    self.postMessage({ error: e.message + "\n" + e.stack });
+    // if you prefer onerror events
+    // setTimeout(() => { throw err; });
+  }
+};

--- a/pytest_pyodide/_templates/module_webworker_dev.js
+++ b/pytest_pyodide/_templates/module_webworker_dev.js
@@ -11,9 +11,6 @@ onmessage = async function (e) {
       }
     }
 
-    if (!loadPyodide.inProgress) {
-      self.pyodide = await loadPyodide();
-    }
     await self.pyodide.loadPackagesFromImports(data.python);
     let results = await self.pyodide.runPythonAsync(data.python);
     self.postMessage({ results });

--- a/pytest_pyodide/_templates/webworker_dev.js
+++ b/pytest_pyodide/_templates/webworker_dev.js
@@ -1,0 +1,26 @@
+importScripts("./pyodide.js");
+
+onmessage = async function (e) {
+  try {
+    const data = e.data;
+    for (let key of Object.keys(data)) {
+      if (key !== "python") {
+        // Keys other than python must be arguments for the python script.
+        // Set them on self, so that `from js import key` works.
+        self[key] = data[key];
+      }
+    }
+
+    if (!loadPyodide.inProgress) {
+      self.pyodide = await loadPyodide();
+    }
+    await self.pyodide.loadPackagesFromImports(data.python);
+    let results = await self.pyodide.runPythonAsync(data.python);
+    self.postMessage({ results });
+  } catch (e) {
+    // if you prefer messages with the error
+    self.postMessage({ error: e.message + "\n" + e.stack });
+    // if you prefer onerror events
+    // setTimeout(() => { throw err; });
+  }
+};

--- a/pytest_pyodide/_templates/webworker_dev.js
+++ b/pytest_pyodide/_templates/webworker_dev.js
@@ -11,9 +11,6 @@ onmessage = async function (e) {
       }
     }
 
-    if (!loadPyodide.inProgress) {
-      self.pyodide = await loadPyodide();
-    }
     await self.pyodide.loadPackagesFromImports(data.python);
     let results = await self.pyodide.runPythonAsync(data.python);
     self.postMessage({ results });

--- a/pytest_pyodide/server.py
+++ b/pytest_pyodide/server.py
@@ -17,7 +17,9 @@ def _default_templates() -> dict[str, bytes]:
     templates_dir = pathlib.Path(__file__).parent / "_templates"
 
     templates = {}
-    template_files = list(templates_dir.glob("*.html")) + list(templates_dir.glob("*.js"))
+    template_files = list(templates_dir.glob("*.html")) + list(
+        templates_dir.glob("*.js")
+    )
     for template_file in template_files:
         templates[f"/{template_file.name}"] = template_file.read_bytes()
 
@@ -53,7 +55,9 @@ class DefaultHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         body = self.get_template(self.path)
         if body:
-            content_type = "application/javascript" if self.path.endswith(".js") else "text/html"
+            content_type = (
+                "application/javascript" if self.path.endswith(".js") else "text/html"
+            )
             self.send_response(200)
             self.send_header("Content-type", f"{content_type}; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))

--- a/pytest_pyodide/server.py
+++ b/pytest_pyodide/server.py
@@ -17,7 +17,8 @@ def _default_templates() -> dict[str, bytes]:
     templates_dir = pathlib.Path(__file__).parent / "_templates"
 
     templates = {}
-    for template_file in templates_dir.glob("*.html"):
+    template_files = list(templates_dir.glob("*.html")) + list(templates_dir.glob("*.js"))
+    for template_file in template_files:
         templates[f"/{template_file.name}"] = template_file.read_bytes()
 
     return templates
@@ -52,8 +53,9 @@ class DefaultHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         body = self.get_template(self.path)
         if body:
+            content_type = "application/javascript" if self.path.endswith(".js") else "text/html"
             self.send_response(200)
-            self.send_header("Content-type", "text/html; charset=utf-8")
+            self.send_header("Content-type", f"{content_type}; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
 


### PR DESCRIPTION
Similar to #87, embed `module_webworker_dev.js` and `webworker_dev.js` files that are used in pytest-pyodide to test webworker functionality.  This is used in `run_webworker` method:

https://github.com/pyodide/pytest-pyodide/blob/bfa37e28050184795d2132f365ec83532ab8e4e5/pytest_pyodide/runner.py#L293-L302

I need this to run webworker tests with `pyodide-core` archive in https://github.com/ryanking13/pyodide-recipes-mirror