### PR TITLE
Drop node < v18 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       with:
         build-artifact-name: none
         build-artifact-path: none
-        pyodide-versions: "0.23.2,0.22.0"
+        pyodide-versions: "0.24.1,0.23.4"
 
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ on:
       pyodide-version:
         required: false
         type: string
-        default: "0.23.2"
+        default: "0.24.1"
       os:
         required: false
         type: string
@@ -145,8 +145,6 @@ jobs:
           else
               ${{needs.get_versions.outputs.pythonexec}} -m pip install pytest-pyodide
           fi
-          which npm && npm install -g npm && npm update
-          which npm && npm install node-fetch@2
       - name: Run tests
         shell: bash -l {0}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
+## unreleased
+
+- BREAKING: dropped support for Node < 18.
+  [#113](https://github.com/pyodide/pytest-pyodide/pull/113)
+
 ## [0.53.1] - 2023-10-10
 
 - Removed the ctypes dependency so it can be used with Python builds with
   dynamic linking disabled.
-  [#110]
-
-## [0.53.0] - 2023-08-29
+  [#110](https://github.com/pyodide/pytest-pyodide/pull/110)
 
 ## [0.53.0] - 2023-08-29
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -5,7 +5,7 @@ Other versions may work, however with no guarantee.
 
 | pytest-pyodide | Tested Pyodide versions |
 |----------------|-------------------------|
-| main branch    | 0.23.4, 0.23.4          |
+| main branch    | 0.23.4, 0.24.1          |
 | 0.53.*         | 0.23.2, 0.22.0          |
 | 0.52.*         | 0.23.2, 0.22.0          |
 | 0.51.*         | 0.23.2, 0.22.0, 0.21.3  |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -5,7 +5,7 @@ Other versions may work, however with no guarantee.
 
 | pytest-pyodide | Tested Pyodide versions |
 |----------------|-------------------------|
-| main branch    | 0.23.2, 0.22.0          |
+| main branch    | 0.23.4, 0.23.4          |
 | 0.53.*         | 0.23.2, 0.22.0          |
 | 0.52.*         | 0.23.2, 0.22.0          |
 | 0.51.*         | 0.23.2, 0.22.0, 0.21.3  |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You would also one at least one of the following runtimes,
  - Chrome and chromedriver
  - Firefox and geckodriver
  - Safari and safaridriver
- - node v14+
+ - node v18+
 
 ## Github Reusable workflow
 
@@ -29,7 +29,7 @@ This will run your tests on the given browser/pyodide version/OS configuration. 
 
 ```
 jobs:
-  # Build for pyodide 0.23.2
+  # Build for pyodide 0.24.1
   build:
     runs-on: ubuntu-latest
     steps:
@@ -39,8 +39,8 @@ jobs:
         python-version: 3.11
     - uses: mymindstorm/setup-emsdk@v11
       with:
-        version: 3.1.32
-    - run: pip install pyodide-build==0.23.2
+        version: 3.1.45
+    - run: pip install pyodide-build==0.24.1
     - run: pyodide build
     - uses: actions/upload-artifact@v3
       with:
@@ -55,7 +55,7 @@ jobs:
       build-artifact-path: dist
       browser: firefox
       runner: selenium
-      pyodide-version: 0.23.2
+      pyodide-version: 0.24.1
 ```
 
 If you want to run on multiple browsers / pyodide versions etc., you can either use a matrix strategy and run main.yaml as above, or you can use testall.yaml. This by default tests on all browsers (and node) with multiple configurations. If you want to reduce the configurations you can filter with lists of browsers, runners, pyodide-versions as shown below.
@@ -66,7 +66,7 @@ If you want to run on multiple browsers / pyodide versions etc., you can either 
     with:
       build-artifact-name: pyodide wheel
       build-artifact-path: dist
-      pyodide-versions: "0.22.0, 0.23.2"
+      pyodide-versions: "0.23.4, 0.24.1"
       runners: "selenium, playwright"
       browsers: "firefox, chrome, node"
       os: "ubuntu-latest, macos-latest"
@@ -76,8 +76,8 @@ If you want to run on multiple browsers / pyodide versions etc., you can either 
 
 1. First you need a compatible version of Pyodide. You can download the Pyodide build artifacts from releases with,
    ```bash
-   wget https://github.com/pyodide/pyodide/releases/download/0.23.2/pyodide-build-0.23.2.tar.bz2
-   tar xjf pyodide-build-0.23.2.tar.bz2
+   wget https://github.com/pyodide/pyodide/releases/download/0.24.1/pyodide-build-0.24.1.tar.bz2
+   tar xjf pyodide-build-0.24.1.tar.bz2
    mv pyodide dist/
    ```
 

--- a/pytest_pyodide/node_test_driver.js
+++ b/pytest_pyodide/node_test_driver.js
@@ -4,10 +4,6 @@ const path = require("path");
 const util = require("util");
 
 let nodeFetch = globalThis.fetch;
-if (!nodeFetch) {
-  nodeFetch = require("node-fetch");
-}
-
 let baseUrl = process.argv[2];
 let distDir = process.argv[3];
 

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -495,13 +495,17 @@ class NodeRunner(_BrowserBaseRunner):
         self.p.sendline("stty -icanon")
 
         node_version = pexpect.spawn("node --version").read().decode("utf-8")
+        node_major = int(node_version.split(".")[0][1:])  # vAA.BB.CC -> AA
+        if node_major < 18:
+            raise RuntimeError(
+                f"Node version {node_version} is too old, please use node >= 18"
+            )
+        
         extra_args = NODE_FLAGS[:]
         # Node v14 require the --experimental-wasm-bigint which
         # produces errors on later versions
         if jspi:
             extra_args.append("--experimental-wasm-stack-switching")
-        if node_version.startswith("v14"):
-            extra_args.append("--experimental-wasm-bigint")
 
         self.p.sendline(
             f"node --expose-gc {' '.join(extra_args)} {curdir}/node_test_driver.js {self.base_url} {self.dist_dir}",

--- a/utils/build_test_matrix.py
+++ b/utils/build_test_matrix.py
@@ -12,7 +12,7 @@ DEFAULT_RUNNER = "selenium, playwright"
 DEFAULT_BROWSER = "chrome, firefox, node, safari, host"
 DEFAULT_CHROME_VERSION = "latest"
 DEFAULT_FIREFOX_VERSION = "latest"
-DEFAULT_NODE_VERSION = "14, 16, 18"
+DEFAULT_NODE_VERSION = "18, 20"
 DEFAULT_PLAYWRIGHT_VERSION = (
     "1.22.0"  # TODO: versions > 1.22.0 have firefox performance issue
 )


### PR DESCRIPTION
Drops node < v18 support from pytest-pyodide. Also update tested Pyodide versions.

- [x] changelog
