### PR TITLE
Add a fixture to reuse safari webdriver

### DIFF
--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -462,17 +462,20 @@ class SeleniumChromeRunner(_SeleniumBaseRunner):
 # reuse it.
 GLOBAL_SAFARI_WEBDRIVER = None
 
+
 @pytest.fixture(scope="session", autouse=True)
 def use_global_safari_service():
     if "safari" in pytest.pyodide_runtimes:
         global GLOBAL_SAFARI_WEBDRIVER
 
-        from selenium.webdriver.safari.service import Service
         from selenium.webdriver.common.driver_finder import DriverFinder
         from selenium.webdriver.safari.options import Options
-        
+        from selenium.webdriver.safari.service import Service
+
         GLOBAL_SAFARI_WEBDRIVER = Service(reuse_service=True)
-        GLOBAL_SAFARI_WEBDRIVER.path = DriverFinder.get_path(GLOBAL_SAFARI_WEBDRIVER, Options())
+        GLOBAL_SAFARI_WEBDRIVER.path = DriverFinder.get_path(
+            GLOBAL_SAFARI_WEBDRIVER, Options()
+        )
         GLOBAL_SAFARI_WEBDRIVER.start()
 
         try:
@@ -492,13 +495,15 @@ class SeleniumSafariRunner(_SeleniumBaseRunner):
             raise NotImplementedError("JSPI not supported in Firefox")
         from selenium.webdriver import Safari
         from selenium.webdriver.safari.options import Options
-        
+
         options = Options()
         if GLOBAL_SAFARI_WEBDRIVER is not None:
-            instance = Safari(options=options, service=GLOBAL_SAFARI_WEBDRIVER, reuse_service=True)
+            instance = Safari(
+                options=options, service=GLOBAL_SAFARI_WEBDRIVER, reuse_service=True
+            )
         else:
             instance = Safari(options=options)
-            
+
         return instance
 
 

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -468,13 +468,19 @@ def use_global_safari_service():
         global GLOBAL_SAFARI_WEBDRIVER
 
         from selenium.webdriver.safari.service import Service
+        from selenium.webdriver.common.driver_finder import DriverFinder
+        from selenium.webdriver.safari.options import Options
+        
         GLOBAL_SAFARI_WEBDRIVER = Service(reuse_service=True)
+        GLOBAL_SAFARI_WEBDRIVER.path = DriverFinder.get_path(GLOBAL_SAFARI_WEBDRIVER, Options())
         GLOBAL_SAFARI_WEBDRIVER.start()
 
         try:
             yield GLOBAL_SAFARI_WEBDRIVER
         finally:
             GLOBAL_SAFARI_WEBDRIVER.stop()
+    else:
+        yield None
 
 
 class SeleniumSafariRunner(_SeleniumBaseRunner):
@@ -484,7 +490,6 @@ class SeleniumSafariRunner(_SeleniumBaseRunner):
     def get_driver(self, jspi=False):
         if jspi:
             raise NotImplementedError("JSPI not supported in Firefox")
-        from selenium.common.exceptions import WebDriverException
         from selenium.webdriver import Safari
         from selenium.webdriver.safari.options import Options
         

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -463,11 +463,20 @@ class SeleniumSafariRunner(_SeleniumBaseRunner):
     def get_driver(self, jspi=False):
         if jspi:
             raise NotImplementedError("JSPI not supported in Firefox")
+        from selenium.common.exceptions import WebDriverException
         from selenium.webdriver import Safari
         from selenium.webdriver.safari.options import Options
+        
 
         options = Options()
-        return Safari(options=options)
+        try:
+            instance = Safari(options=options)
+        except WebDriverException:
+            from selenium.webdriver.safari.service import Service
+            service = Service(reuse_service=False)
+            instance = Safari(options=options, service=service)
+            
+        return instance
 
 
 class PlaywrightChromeRunner(_PlaywrightBaseRunner):

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -462,7 +462,7 @@ class SeleniumChromeRunner(_SeleniumBaseRunner):
 # reuse it.
 GLOBAL_SAFARI_WEBDRIVER = None
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def use_global_safari_service():
     if "safari" in pytest.pyodide_runtimes:
         global GLOBAL_SAFARI_WEBDRIVER

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -495,7 +495,7 @@ class SeleniumSafariRunner(_SeleniumBaseRunner):
         
         options = Options()
         if GLOBAL_SAFARI_WEBDRIVER is not None:
-            instance = Safari(options=options, service=GLOBAL_SAFARI_WEBDRIVER)
+            instance = Safari(options=options, service=GLOBAL_SAFARI_WEBDRIVER, reuse_service=True)
         else:
             instance = Safari(options=options)
             

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -465,7 +465,7 @@ GLOBAL_SAFARI_WEBDRIVER = None
 
 @pytest.fixture(scope="session", autouse=True)
 def use_global_safari_service():
-    if "safari" in pytest.pyodide_runtimes:
+    if "safari" in pytest.pyodide_runtimes:  # type: ignore[operator]
         global GLOBAL_SAFARI_WEBDRIVER
 
         from selenium.webdriver.common.driver_finder import DriverFinder


### PR DESCRIPTION
This PR adds a fixture `use_global_safari_service`. It makes safari runner to use a pre-initiated webdriver during the whole test session, instead of starting/stopping the webdriver for each test / module.

I think normally reusing a process is a bad idea, but Pyodide CI fails when starting a webdriver multiple times... so I guess this can be a workaround.

- Reference: https://www.selenium.dev/selenium/docs/api/py/webdriver_safari/selenium.webdriver.safari.webdriver.html#selenium.webdriver.safari.webdriver.WebDriver
- xref PR: https://github.com/pyodide/pyodide/pull/4270