### PR TITLE
ENH run_in_pyodide type annotations, defaults, posonly, and kwonly args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## unreleased
+## Unreleased
+
+- Added support in `@run_in_pyodide` positional only and keyword only arguments,
+  type annotations, and argument default values.
+  [#116](https://github.com/pyodide/pytest-pyodide/pull/116)
 
 ## [0.54.0] - 2023-11/04
 

--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -385,11 +385,17 @@ class run_in_pyodide:
                 )
 
             self._async_func = isinstance(node, ast.AsyncFunctionDef)
+            # Clear out things that won't be in scope when we exec the ast.
+            # decorators, annotations, and default values all have to go.
             node.decorator_list = []
             for arg in node.args.args:
                 arg.annotation = None
-            node.args.defaults = []
             node.returns = None
+            node.args.defaults = []
+            # For the inner node, turn all kwonly args into positional args. The
+            # outer node cannot be changed like this because it is called
+            # directly by the user, but we don't want to deal with kwonly args,
+            # it's easier to pass everything by position.
             inner_node = deepcopy(node)
             args = inner_node.args
             args.args.extend(args.kwonlyargs)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 from hypothesis import given, settings
 
@@ -340,7 +342,7 @@ def test_defaults1(selenium):
 
 def test_defaults2_from_local_variables(selenium):
     """Check that defaults that variables in defaults are resolved correctly"""
-    a = 5
+    a = Callable
     b = 6
     c = 7
     d = 8

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -306,18 +306,19 @@ def test_typehints(selenium):
     from typing import Any
 
     def fn_with_typehints(selenium, a: Any, b: Callable) -> Any:
-        return None
+        return [a, b]
 
     wrapped = run_in_pyodide(fn_with_typehints)
 
-    wrapped(selenium, 5, Callable)
+    assert wrapped(selenium, 5, Callable) == [5, Callable]
     assert wrapped.__annotations__ == fn_with_typehints.__annotations__
 
 
 def test_posonly(selenium):
     @run_in_pyodide
     def fn_with_posonly(selenium, a, /, b):
-        return None
+        assert a == 5
+        assert b == 7
 
     fn_with_posonly(selenium, 5, 7)
 
@@ -325,7 +326,8 @@ def test_posonly(selenium):
 def test_kwonly(selenium):
     @run_in_pyodide
     def fn_with_kwonly(selenium, *, a, b):
-        return None
+        assert a == 5
+        assert b == 7
 
     fn_with_kwonly(selenium, a=5, b=7)
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -296,3 +296,57 @@ def test_pytest_dot_skip(selenium):
     for meth in ["skip", "fail", "xfail"]:
         with pytest.raises(getattr(pytest, meth).Exception):
             helper(selenium, meth)
+
+
+def test_typehints(selenium):
+    """Check that typehints are resolved correctly"""
+    from collections.abc import Callable
+    from typing import Any
+
+    def fn_with_typehints(selenium, a: Any, b: Callable) -> Any:
+        return None
+
+    wrapped = run_in_pyodide(fn_with_typehints)
+
+    wrapped(selenium, 5, Callable)
+    assert wrapped.__annotations__ == fn_with_typehints.__annotations__
+
+
+def test_posonly(selenium):
+    @run_in_pyodide
+    def fn_with_posonly(selenium, a, /, b):
+        return None
+
+    fn_with_posonly(selenium, 5, 7)
+
+
+def test_kwonly(selenium):
+    @run_in_pyodide
+    def fn_with_kwonly(selenium, *, a, b):
+        return None
+
+    fn_with_kwonly(selenium, a=5, b=7)
+
+
+def test_defaults1(selenium):
+    """Check that defaults are kept"""
+
+    @run_in_pyodide
+    def fn_with_defaults(selenium, a=5, b=6, *, c=7, d=8):
+        return [a, b, c, d]
+
+    assert fn_with_defaults(selenium) == [5, 6, 7, 8]
+
+
+def test_defaults2_from_local_variables(selenium):
+    """Check that defaults that variables in defaults are resolved correctly"""
+    a = 5
+    b = 6
+    c = 7
+    d = 8
+
+    @run_in_pyodide
+    def fn_with_defaults(selenium, a=a, b=b, *, c=c, d=d):
+        return [a, b, c, d]
+
+    assert fn_with_defaults(selenium) == [a, b, c, d]


### PR DESCRIPTION
It still doesn't support *args or **kwargs arguments though.

- [x] Add tests
- [ ] Update changelog