### PR TITLE
ENH Add support for running doctests in pyodide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## unreleased
+## Unreleased
+
+- Added support for running doctests in Pyodide if they have
+  `# doctest: +RUN_IN_PYODIDE` on the first line.
+  [#117](https://github.com/pyodide/pytest-pyodide/pull/117)
 
 ## [0.54.0] - 2023-11/04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+## [0.54.0] - 2023-11/04
+
 - BREAKING: dropped support for Node < 18.
   [#113](https://github.com/pyodide/pytest-pyodide/pull/113)
 

--- a/pytest_pyodide/doctest.py
+++ b/pytest_pyodide/doctest.py
@@ -101,8 +101,11 @@ def run_doctest_in_pyodide_inner(
     # in our tests.
     from importlib import import_module
 
-    mod = import_module(test.globs["__name__"])
-    test.globs = mod.__dict__.copy()
+    try:
+        mod = import_module(test.globs["__name__"])
+        test.globs = mod.__dict__.copy()
+    except ModuleNotFoundError:
+        pass
     try:
         return self.run(test, compileflags, out, clear_globs)
     except Exception:

--- a/pytest_pyodide/doctest.py
+++ b/pytest_pyodide/doctest.py
@@ -33,11 +33,10 @@ class PyodideDoctestMixin:
         """
         for item in super().collect():  # type:ignore[misc]
             if RUN_IN_PYODIDE not in item.dtest.examples[0].options:
-                yield item
+                if pytest.pyodide_run_host_test:
+                    yield item
                 continue
             for runtime in pytest.pyodide_runtimes:  # type: ignore[attr-defined]
-                if runtime == "host":
-                    continue
                 x = copy(item)
                 x.dtest = copy(item.dtest)
                 x.name += f"[{runtime}]"

--- a/pytest_pyodide/doctest.py
+++ b/pytest_pyodide/doctest.py
@@ -1,0 +1,156 @@
+import ast
+from collections.abc import Callable
+from copy import copy
+from doctest import DocTest, DocTestRunner, register_optionflag
+from pathlib import Path
+
+import pytest
+from _pytest.doctest import (
+    DoctestModule,
+    DoctestTextfile,
+    _is_doctest,
+    _is_main_py,
+    _is_setup_py,
+)
+from pytest import Collector
+
+from . import run_in_pyodide
+from .hook import ORIGINAL_MODULE_ASTS
+from .run_tests_inside_pyodide import get_browser_pyodide
+
+RUN_IN_PYODIDE = register_optionflag("RUN_IN_PYODIDE")
+ORIGINAL_MODULE_ASTS[__file__] = ast.parse(
+    Path(__file__).read_bytes(), filename=__file__
+)
+
+__all__ = ["patch_doctest_runner", "collect_doctests"]
+
+
+class PyodideDoctestMixin:
+    def collect(self):
+        """Call super and then if test includes the RUN_IN_PYODIDE option on the
+        first line, make one copy for each Pyodide runtime environment
+        """
+        for item in super().collect():  # type:ignore[misc]
+            if RUN_IN_PYODIDE not in item.dtest.examples[0].options:
+                yield item
+                continue
+            for runtime in pytest.pyodide_runtimes:  # type: ignore[attr-defined]
+                if runtime == "host":
+                    continue
+                x = copy(item)
+                x.dtest = copy(item.dtest)
+                x.name += f"[{runtime}]"
+                x._nodeid += f"[{runtime}]"
+                x.dtest.pyodide_runtime = runtime
+                yield x
+
+
+class PyodideDoctestModule(PyodideDoctestMixin, DoctestModule):
+    pass
+
+
+class PyodideDoctestTextfile(PyodideDoctestMixin, DoctestTextfile):
+    pass
+
+
+def collect_doctests(
+    file_path: Path, parent: Collector, doctestmodules: bool
+) -> PyodideDoctestModule | PyodideDoctestTextfile | None:
+    """This is similar to _pytest.doctest.pytest_collect_file but it uses
+    PyodideDoctestModule and PyodideDoctestTextfile which may run tests in
+    Pyodide.
+    """
+    if (
+        doctestmodules
+        and file_path.suffix == ".py"
+        and not any((_is_setup_py(file_path), _is_main_py(file_path)))
+    ):
+        return PyodideDoctestModule.from_parent(parent, path=file_path)
+    if _is_doctest(parent.config, file_path, parent):
+        return PyodideDoctestTextfile.from_parent(parent, path=file_path)
+    return None
+
+
+@run_in_pyodide(pytest_assert_rewrites=False, packages=["pytest"])
+def run_doctest_in_pyodide_inner(
+    selenium,
+    optionflags,
+    continue_on_failure,
+    test,
+    compileflags,
+    out,
+    clear_globs,
+):
+    # Recreate the DocTestRunner
+    #
+    # It would reduce the amount of pytest internals we have to touch to
+    # pickle the DocTestRunner rather than recreating it but it didn't seem
+    # to work.
+    from _pytest.doctest import _get_checker, _get_runner
+
+    self = _get_runner(
+        verbose=False,
+        optionflags=optionflags,
+        checker=_get_checker(),
+        continue_on_failure=continue_on_failure,
+    )
+
+    # Put the appropriate global variables back. We do a lot less than what
+    # doctest does here, but we currently don't anything but module globals
+    # in our tests.
+    from importlib import import_module
+
+    mod = import_module(test.globs["__name__"])
+    test.globs = mod.__dict__.copy()
+    try:
+        return self.run(test, compileflags, out, clear_globs)
+    except Exception:
+        # Some exceptions carry a reference to the test which cannot be
+        # pickled with its global variables. Clear them out to ensure that
+        # we can pickle the exception we threw.
+        test.globs = {}
+        raise
+
+
+host_DocTestRunner_run = DocTestRunner.run
+
+
+def run_doctest_in_pyodide_outer(
+    self: DocTestRunner,
+    test: DocTest,
+    compileflags: int | None = None,
+    out: Callable[[str], object] | None = None,
+    clear_globs: bool = True,
+):
+    if not hasattr(test, "pyodide_runtime"):
+        # Run host test as normal
+        return host_DocTestRunner_run(self, test, compileflags, out, clear_globs)
+
+    # pytest conveniently inserts getfixture into the test globals. This saves
+    # us a lot of effort.
+    getfixture = test.globs["getfixture"]
+    request = getfixture("request")
+    selenium = get_browser_pyodide(request, test.pyodide_runtime)
+
+    # Can't pickle test with its globals. We retain the __name__ so that we can
+    # figure out how to restore the globals inside of pyodide.
+    test.globs = {k: test.globs[k] for k in ["__name__"]}
+
+    # It would be nice if we could pickle DocTestRunner, but pytest has made it
+    # very not pickleable. After fixing a few name resolution issues I can get
+    # it to pickle successfully but I get some pickle internal error on
+    # unpickling.
+    #
+    # So we just take the DocTestRunner apart and put it back together inside
+    # Pyodide.
+    optionflags = self.optionflags
+    continue_on_failure = self.continue_on_failure  # type:ignore[attr-defined]
+
+    return run_doctest_in_pyodide_inner(
+        selenium, optionflags, continue_on_failure, test, compileflags, out, clear_globs
+    )
+
+
+def patch_doctest_runner() -> None:
+    DocTestRunner.run = run_doctest_in_pyodide_outer  # type: ignore[method-assign]

--- a/pytest_pyodide/doctest.py
+++ b/pytest_pyodide/doctest.py
@@ -104,6 +104,8 @@ def run_doctest_in_pyodide_inner(
         mod = import_module(test.globs["__name__"])
         test.globs = mod.__dict__.copy()
     except ModuleNotFoundError:
+        # Oops the test file isn't in the Pyodide file system.
+        # TODO: maybe we shouldn't suppress this error??
         pass
     try:
         return self.run(test, compileflags, out, clear_globs)

--- a/pytest_pyodide/fixture.py
+++ b/pytest_pyodide/fixture.py
@@ -266,6 +266,9 @@ def selenium_context_manager(selenium_module_scope):
         try:
             print(selenium_module_scope.logs)
         except ValueError:
+            # For reasons I don't entirely understand, it is possible for
+            # selenium to be closed before this is executed. In that case, just
+            # skip printing the logs and we can exit cleanly.
             pass
 
 

--- a/pytest_pyodide/fixture.py
+++ b/pytest_pyodide/fixture.py
@@ -263,7 +263,10 @@ def selenium_context_manager(selenium_module_scope):
         selenium_module_scope.clean_logs()
         yield selenium_module_scope
     finally:
-        print(selenium_module_scope.logs)
+        try:
+            print(selenium_module_scope.logs)
+        except ValueError:
+            pass
 
 
 @pytest.fixture

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -179,7 +179,8 @@ def pytest_collect_file(file_path: Path, parent: Collector):
     doctestmodules = getattr(parent.config.option, "doctestmodules_", False)
     from .doctest import collect_doctests
 
-    # call our collection hook instead
+    # Call our collection hook instead. (If there are no doctests to collect,
+    # collect_doctests will return None)
     return collect_doctests(file_path, parent, doctestmodules)
 
 
@@ -238,13 +239,12 @@ def _has_standalone_fixture(item):
 
 
 def modifyitems_run_in_pyodide(items: list[Any]):
+    # TODO: get rid of this
     # if we are running tests in pyodide, then run all tests for each runtime
-    if not items:
-        return
     new_items = []
-    # TODO: if pyodide_runtimes is not a singleton this is buggy...
-    # pytest_collection_modifyitems is only allowed to filter and reorder the
-    # items, not to remove them...
+    # if pyodide_runtimes is not a singleton this is buggy...
+    # pytest_collection_modifyitems is only allowed to filter and reorder items,
+    # not to add new ones...
     for runtime in pytest.pyodide_runtimes:  # type: ignore[attr-defined]
         if runtime == "host":
             continue

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -71,6 +71,11 @@ def _filter_runtimes(runtime: str) -> tuple[bool, set[str]]:
     return run_host, runtime_filtered
 
 
+def pytest_unconfigure(config):
+    if config.option.run_in_pyodide:
+        close_pyodide_browsers()
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -150,7 +150,7 @@ def pytest_collect_file(file_path: Path, parent: Collector):
     # Have to set doctestmodules to False to prevent original hook from
     # triggering
     parent.config.option.doctestmodules = False
-    doctestmodules = parent.config.option.doctestmodules_
+    doctestmodules = getattr(parent.config.option, "doctestmodules_", False)
     from .doctest import collect_doctests
 
     # call our collection hook instead

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -92,6 +92,7 @@ def pytest_configure(config):
         "xfail_browsers: xfail a test in specific browsers",
     )
 
+    config.option.dist_dir = config.option.dist_dir.resolve()
     run_host, runtimes = _filter_runtimes(config.option.runtime)
 
     if not hasattr(pytest, "pyodide_options_stack"):
@@ -106,7 +107,7 @@ def pytest_configure(config):
         )
     pytest.pyodide_run_host_test = run_host
     pytest.pyodide_runtimes = runtimes
-    pytest.pyodide_dist_dir = config.getoption("--dist-dir")
+    pytest.pyodide_dist_dir = config.option.dist_dir
 
 
 def pytest_unconfigure(config):
@@ -126,6 +127,7 @@ def pytest_addoption(parser):
     group = parser.getgroup("general")
     group.addoption(
         "--dist-dir",
+        dest="dist_dir",
         action="store",
         default="pyodide",
         help="Path to the pyodide dist directory",

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -71,11 +71,6 @@ def _filter_runtimes(runtime: str) -> tuple[bool, set[str]]:
     return run_host, runtime_filtered
 
 
-def pytest_unconfigure(config):
-    if config.option.run_in_pyodide:
-        close_pyodide_browsers()
-
-
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
@@ -165,11 +160,9 @@ def pytest_addoption(parser):
 def runtime(request):
     return request.param
 
-
 def set_runtime_fixture_params(session):
     rt = session._fixturemanager._arg2fixturedefs["runtime"]
     rt[0].params = pytest.pyodide_runtimes
-
 
 def pytest_collection(session: Session):
     from .doctest import patch_doctest_runner
@@ -225,6 +218,8 @@ def pytest_pycollect_makemodule(module_path: Path, parent: Collector) -> None:
     rewrite_asserts(tree2, source, strfn, REWRITE_CONFIG)
     REWRITTEN_MODULE_ASTS[strfn] = tree2
     orig_pytest_pycollect_makemodule(module_path, parent)
+
+
 
 
 STANDALONE_FIXTURES = [

--- a/pytest_pyodide/run_tests_inside_pyodide.py
+++ b/pytest_pyodide/run_tests_inside_pyodide.py
@@ -165,4 +165,4 @@ def close_pyodide_browsers():
     global _seleniums, _playwright_browser_list, _playwright_browser_generator
     for x in _seleniums.values():
         x.selenium.close()
-    del _seleniums
+    _seleniums.clear()

--- a/pytest_pyodide/run_tests_inside_pyodide.py
+++ b/pytest_pyodide/run_tests_inside_pyodide.py
@@ -162,7 +162,6 @@ def close_pyodide_browsers():
     This is done at the end of testing so that we can run more
     than one test without launching browsers each time.
     """
-    global _seleniums, _playwright_browser_list, _playwright_browser_generator
     for x in _seleniums.values():
         x.selenium.close()
-    del _seleniums
+    _seleniums.clear()

--- a/pytest_pyodide/run_tests_inside_pyodide.py
+++ b/pytest_pyodide/run_tests_inside_pyodide.py
@@ -1,83 +1,33 @@
 import re
 import sys
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
-from typing import ContextManager
+from contextlib import ExitStack
+from functools import cache
 
 import pytest
 
-from .server import spawn_web_server
+from .fixture import selenium_common
+
+_CLEANUP = ExitStack()
 
 
-class ContextManagerUnwrapper:
-    """Class to take a context manager (e.g. a pytest fixture or something)
-    and unwrap it so that it can be used for the whole of the module.
-
-    This is a bit of a hack, but it allows us to use some of our pytest fixtures
-    without having to be inside a pytest context. Avoids significant duplication
-    of the standard pytest_pyodide code here.
-    """
-
-    def __init__(self, ctx_manager: ContextManager):
-        self.ctx_manager = ctx_manager
-        self.value = ctx_manager.__enter__()
-
-    def get_value(self):
-        return self.value
-
-    def __del__(self):
-        self.close()
-
-    def close(self):
-        if self.ctx_manager is not None:
-            self.ctx_manager.__exit__(None, None, None)
-            self.value = None
-
-
-@dataclass
-class _SeleniumInstance:
-    selenium: ContextManagerUnwrapper
-    server: ContextManagerUnwrapper
-
-
-_seleniums: dict[str, _SeleniumInstance] = {}
-_playwright_browser_list = None
-_playwright_browser_generator = None
-
-
+@cache
 def get_browser_pyodide(request: pytest.FixtureRequest, runtime: str):
     """Start a browser running with pyodide, ready to run pytest
     calls. If the same runtime is already running, it will
     just return that.
     """
-    global _playwright_browser_generator, _playwright_browser_list
-    from .fixture import _playwright_browsers, selenium_common
-
-    if (
-        request.config.option.runner.lower() == "playwright"
-        and _playwright_browser_generator is None
-    ):
-        _playwright_browser_generator = _playwright_browsers(request)
-        _playwright_browser_list = _playwright_browser_generator.__next__()
-    if runtime in _seleniums:
-        return _seleniums[runtime].selenium.get_value()
-    web_server_main = ContextManagerUnwrapper(
-        spawn_web_server(request.config.option.dist_dir)
-    )
+    browsers = request.getfixturevalue("playwright_browsers")
+    web_server_main = request.getfixturevalue("web_server_main")
     # open pyodide
-    _seleniums[runtime] = _SeleniumInstance(
-        selenium=ContextManagerUnwrapper(
-            selenium_common(
-                request,
-                runtime,
-                web_server_main.get_value(),
-                browsers=_playwright_browser_list,
-            )
-        ),
-        server=web_server_main,
+    return _CLEANUP.enter_context(
+        selenium_common(
+            request,
+            runtime,
+            web_server_main,
+            browsers=browsers,
+        )
     )
-
-    return _seleniums[runtime].selenium.get_value()
 
 
 def _remove_pytest_capture_title(
@@ -162,6 +112,5 @@ def close_pyodide_browsers():
     This is done at the end of testing so that we can run more
     than one test without launching browsers each time.
     """
-    for x in _seleniums.values():
-        x.selenium.close()
-    _seleniums.clear()
+    get_browser_pyodide.cache_clear()
+    _CLEANUP.close()

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -29,12 +29,11 @@ def host_success():
 
 def test_doctest_run(pytester, request):
     pytester.makepyfile(DOCTESTS)
-    from pathlib import Path
 
     result = pytester.runpytest(
         "--doctest-modules",
         "--dist-dir",
-        Path(__file__).parents[1] / "pyodide",
+        request.config.getoption("--dist-dir"),
         "--rt",
         request.config.option.runtime,
     )

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -36,8 +37,12 @@ def host_success():
     '''
 """
 
+ORIG_HOME = os.environ.get("HOME", None)
+
 
 def test_doctest_run(pytester, request):
+    # Help playwright find the cache
+    os.environ["XDG_CACHE_HOME"] = str(Path(ORIG_HOME) / ".cache")
     pytester.makepyfile(DOCTESTS)
 
     @run_in_pyodide

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,0 +1,52 @@
+from textwrap import dedent
+
+
+def test_doctest1(pytester):
+    pytester.makepyfile(
+        dedent(
+            """
+            def doctest_pyodide_success():
+                '''
+                >>> from js import Object # doctest: +RUN_IN_PYODIDE
+                >>> import sys
+                >>> sys.platform == "emscripten"
+                True
+                '''
+
+            def doctest_pyodide_fail():
+                '''
+                >>> from js import Object # doctest: +RUN_IN_PYODIDE
+                >>> 1 == 2
+                True
+                '''
+
+            def doctest_host_success():
+                '''
+                >>> import sys
+                >>> sys.platform == "emscripten"
+                False
+                '''
+            """
+        )
+    )
+    from pathlib import Path
+
+    result = pytester.runpytest(
+        "--doctest-modules", "--dist-dir", Path(__file__).parents[1] / "pyodide"
+    )
+    result.assert_outcomes(passed=2, failed=1)
+    result.stdout.fnmatch_lines(
+        dedent(
+            """
+            011     >>> from js import Object # doctest: +RUN_IN_PYODIDE
+            012     >>> 1 == 2
+            Expected:
+                True
+            Got:
+                False
+            """
+        )
+        .strip()
+        .splitlines(),
+        consecutive=True,
+    )

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -2,36 +2,34 @@ from textwrap import dedent
 
 import pytest
 
+DOCTESTS = """\
+def pyodide_success():
+    '''
+    >>> from js import Object # doctest: +RUN_IN_PYODIDE
+    >>> import sys
+    >>> sys.platform == "emscripten"
+    True
+    '''
+
+def pyodide_fail():
+    '''
+    >>> from js import Object # doctest: +RUN_IN_PYODIDE
+    >>> 1 == 2
+    True
+    '''
+
+def host_success():
+    '''
+    >>> import sys
+    >>> sys.platform == "emscripten"
+    False
+    '''
+"""
+
 
 @pytest.mark.parametrize("runtime1", ["chrome"])
-def test_doctest1(pytester, runtime1):
-    pytester.makepyfile(
-        dedent(
-            """
-            def doctest_pyodide_success():
-                '''
-                >>> from js import Object # doctest: +RUN_IN_PYODIDE
-                >>> import sys
-                >>> sys.platform == "emscripten"
-                True
-                '''
-
-            def doctest_pyodide_fail():
-                '''
-                >>> from js import Object # doctest: +RUN_IN_PYODIDE
-                >>> 1 == 2
-                True
-                '''
-
-            def doctest_host_success():
-                '''
-                >>> import sys
-                >>> sys.platform == "emscripten"
-                False
-                '''
-            """
-        )
-    )
+def test_doctest_run(pytester, runtime1):
+    pytester.makepyfile(DOCTESTS)
     from pathlib import Path
 
     result = pytester.runpytest(
@@ -60,3 +58,25 @@ def test_doctest1(pytester, runtime1):
         .splitlines(),
         consecutive=True,
     )
+
+
+def test_doctest_collect(pytester):
+    BROWSERS = ["chrome", "firefox", "node", "safari"]
+    BROWSER_TESTS = []
+    for b in BROWSERS:
+        BROWSER_TESTS.append(f"pyodide_fail[{b}]"),
+        BROWSER_TESTS.append(f"pyodide_success[{b}]"),
+    HOST_TESTS = ["host_success"]
+
+    def check(rt, expected):
+        path = pytester.makepyfile(DOCTESTS)
+        items, reprec = pytester.inline_genitems(
+            path, "--doctest-modules", "--rt", ",".join(rt)
+        )
+        assert sorted(
+            [i.name.removeprefix("test_doctest_collect.") for i in items]
+        ) == sorted(expected)
+
+    check(BROWSERS + ["chrome-no-host"], BROWSER_TESTS)
+    check(["host"], HOST_TESTS)
+    check(BROWSERS + ["host"], BROWSER_TESTS + HOST_TESTS)

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -27,8 +27,7 @@ def host_success():
 """
 
 
-@pytest.mark.parametrize("runtime1", ["chrome"])
-def test_doctest_run(pytester, runtime1):
+def test_doctest_run(pytester, request):
     pytester.makepyfile(DOCTESTS)
     from pathlib import Path
 
@@ -37,9 +36,9 @@ def test_doctest_run(pytester, runtime1):
         "--dist-dir",
         Path(__file__).parents[1] / "pyodide",
         "--rt",
-        "chrome",
+        request.config.option.runtime,
     )
-    if runtime1 == "host":
+    if not pytest.pyodide_runtimes:
         result.assert_outcomes(passed=1)
         return
     result.assert_outcomes(passed=2, failed=1)
@@ -58,9 +57,6 @@ def test_doctest_run(pytester, runtime1):
         .splitlines(),
         consecutive=True,
     )
-    from pytest_pyodide.run_tests_inside_pyodide import close_pyodide_browsers
-
-    close_pyodide_browsers()
 
 
 def test_doctest_collect(pytester):

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -58,6 +58,9 @@ def test_doctest_run(pytester, runtime1):
         .splitlines(),
         consecutive=True,
     )
+    from pytest_pyodide.run_tests_inside_pyodide import close_pyodide_browsers
+
+    close_pyodide_browsers()
 
 
 def test_doctest_collect(pytester):

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,7 +1,10 @@
 from textwrap import dedent
 
+import pytest
 
-def test_doctest1(pytester):
+
+@pytest.mark.parametrize("runtime1", ["chrome"])
+def test_doctest1(pytester, runtime1):
     pytester.makepyfile(
         dedent(
             """
@@ -32,8 +35,15 @@ def test_doctest1(pytester):
     from pathlib import Path
 
     result = pytester.runpytest(
-        "--doctest-modules", "--dist-dir", Path(__file__).parents[1] / "pyodide"
+        "--doctest-modules",
+        "--dist-dir",
+        Path(__file__).parents[1] / "pyodide",
+        "--rt",
+        "chrome",
     )
+    if runtime1 == "host":
+        result.assert_outcomes(passed=1)
+        return
     result.assert_outcomes(passed=2, failed=1)
     result.stdout.fnmatch_lines(
         dedent(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from textwrap import dedent
+
 import pytest
 
 from pytest_pyodide.hook import _filter_runtimes
@@ -86,3 +89,35 @@ def test_invalid_runtime(pytester, _runtime):
 )
 def test_filter_runtimes(_runtime, expected):
     assert _filter_runtimes(_runtime) == expected
+
+
+def test_options_pytester(pytester):
+    pytester.makepyfile(
+        dedent(
+            """
+            import pytest
+
+            def test_options_pytester():
+                assert pytest.pyodide_run_host_test == True
+                assert pytest.pyodide_runtimes == set(["chrome","firefox","safari","node"])
+                assert str(pytest.pyodide_dist_dir) == "some_weird_dir"
+            """
+        )
+    )
+    run_host = pytest.pyodide_run_host_test
+    runtimes = pytest.pyodide_runtimes
+    dist_dir = pytest.pyodide_dist_dir
+
+    result = pytester.runpytest(
+        "--dist-dir",
+        Path(__file__).parents[1] / "pyodide",
+        "--rt",
+        "chrome,firefox,safari,node",
+        "--dist-dir",
+        "some_weird_dir",
+    )
+    result.assert_outcomes(passed=1)
+
+    assert run_host == pytest.pyodide_run_host_test
+    assert runtimes == pytest.pyodide_runtimes
+    assert dist_dir == pytest.pyodide_dist_dir

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -7,7 +7,7 @@ from pytest_pyodide.hook import _filter_runtimes
 
 
 def test_dist_dir(pytester):
-    dist_dir = "dist"
+    dist_dir = str(Path("dist").resolve())
 
     pytester.makepyfile(
         f"""
@@ -17,7 +17,7 @@ def test_dist_dir(pytester):
         """
     )
 
-    result = pytester.runpytest("--dist-dir", dist_dir)
+    result = pytester.runpytest("--dist-dir", "dist")
     result.assert_outcomes(passed=1)
 
 
@@ -96,11 +96,12 @@ def test_options_pytester(pytester):
         dedent(
             """
             import pytest
+            from pathlib import Path
 
             def test_options_pytester():
                 assert pytest.pyodide_run_host_test == True
                 assert pytest.pyodide_runtimes == set(["chrome","firefox","safari","node"])
-                assert str(pytest.pyodide_dist_dir) == "some_weird_dir"
+                assert pytest.pyodide_dist_dir == Path("some_weird_dir").resolve()
             """
         )
     )


### PR DESCRIPTION
If the first line of the doctest has `# doctest: +RUN_IN_PYODIDE`, then we will run it in Pyodide once for each runtime available.

- [x] add a test
- [x] update changelog