### PR TITLE
Use new tblib 3.0 features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "hypothesis",
   "selenium",
   "playwright",
-  "pyodide-tblib", # Forked to add https://github.com/ionelmc/python-tblib/pull/66
+  "tblib>=3", # Forked to add https://github.com/ionelmc/python-tblib/pull/66
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "hypothesis",
   "selenium",
   "playwright",
-  "tblib>=3", # Forked to add https://github.com/ionelmc/python-tblib/pull/66
+  "tblib>=3",
 ]
 
 [project.optional-dependencies]

--- a/pytest_pyodide/_decorator_in_pyodide.py
+++ b/pytest_pyodide/_decorator_in_pyodide.py
@@ -125,7 +125,20 @@ async def run_in_pyodide_main(
             # If tblib is present, we can show much better tracebacks.
             from tblib import pickling_support
 
-            pickling_support.install()
+            def pickle_locals(frame):
+                result = {}
+                tbhide = frame.f_locals.get("__tracebackhide__")
+                if tbhide:
+                    result["__tracebackhide__"] = tbhide
+                return result
+
+            try:
+                # works if we are using tblib >= 3.0
+                pickling_support.install(pickle_locals=pickle_locals)
+            except TypeError:
+                # tblib < 3 or pyodide-tblib
+                pickling_support.install()
+
         except ImportError:
             pass
         return (1, encode(e))

--- a/pytest_pyodide/_decorator_in_pyodide.py
+++ b/pytest_pyodide/_decorator_in_pyodide.py
@@ -125,7 +125,7 @@ async def run_in_pyodide_main(
             # If tblib is present, we can show much better tracebacks.
             from tblib import pickling_support
 
-            def pickle_locals(frame):
+            def get_locals(frame):
                 result = {}
                 tbhide = frame.f_locals.get("__tracebackhide__")
                 if tbhide:
@@ -134,7 +134,7 @@ async def run_in_pyodide_main(
 
             try:
                 # works if we are using tblib >= 3.0
-                pickling_support.install(pickle_locals=pickle_locals)
+                pickling_support.install(get_locals=get_locals)
             except TypeError:
                 # tblib < 3 or pyodide-tblib
                 pickling_support.install()


### PR DESCRIPTION
tblib 3.0 has been released with support for pickling frame locals:
https://github.com/ionelmc/python-tblib/issues/41
This PR attempts to use the new tblib 3.0 feature, with a fallback for older Pyodide versions