### PR TITLE
Remove reuse_service parameter from safari webdriver constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.55.1] - 2023-11-17
+
+- Reverted [#121](https://github.com/pyodide/pytest-pyodide/pull/121)
+
 ## [0.55.0] - 2023-11-17
 
 - If Pyodide includes tblib 3.0, pytest-pyodide will now use it correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.56.0] - 2023-12-09
+
+- Added webworker test template files into the package.
+  [#112](https://github.com/pyodide/pytest-pyodide/pull/112)
+
 ## [0.55.1] - 2023-11-17
 
 - Reverted [#121](https://github.com/pyodide/pytest-pyodide/pull/121)
@@ -27,9 +32,6 @@
 
 - BREAKING: dropped support for Node < 18.
   [#113](https://github.com/pyodide/pytest-pyodide/pull/113)
-
-- Added webworker test template files into the package.
-  [#112](https://github.com/pyodide/pytest-pyodide/pull/112)
 
 ## [0.53.1] - 2023-10-10
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,8 +4,11 @@ Following versions of pytest-pyodide and Pyodide are tested in CI.
 Other versions may work, however with no guarantee.
 
 | pytest-pyodide | Tested Pyodide versions |
-|----------------|-------------------------|
+| -------------- | ----------------------- |
 | main branch    | 0.23.4, 0.24.1          |
+| 0.56.*         | 0.23.4, 0.24.1          |
+| 0.55.*         | 0.23.4, 0.24.1          |
+| 0.54.*         | 0.23.4, 0.24.1          |
 | 0.53.*         | 0.23.2, 0.22.0          |
 | 0.52.*         | 0.23.2, 0.22.0          |
 | 0.51.*         | 0.23.2, 0.22.0, 0.21.3  |

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -499,7 +499,7 @@ class SeleniumSafariRunner(_SeleniumBaseRunner):
         options = Options()
         if GLOBAL_SAFARI_WEBDRIVER is not None:
             instance = Safari(
-                options=options, service=GLOBAL_SAFARI_WEBDRIVER, reuse_service=True
+                options=options, service=GLOBAL_SAFARI_WEBDRIVER,
             )
         else:
             instance = Safari(options=options)


### PR DESCRIPTION
This parameter has been removed from selenium 4.16

Related: https://github.com/pyodide/pyodide/pull/4333#issuecomment-1848081420