### PR TITLE
sorry, finally fixing it - moving to the build.yml that is in actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pytest-pyodide
 
 [![PyPI Latest Release](https://img.shields.io/pypi/v/pytest-pyodide.svg)](https://pypi.org/project/pytest-pyodide/)
-[![GHA](https://github.com/pyodide/pytest-pyodide/actions/workflows/main.yml/badge.svg)
+![GHA](https://github.com/pyodide/pytest-pyodide/actions/workflows/build.yml/badge.svg)
 [![codecov](https://codecov.io/gh/pyodide/pytest-pyodide/branch/main/graph/badge.svg?token=U7tWHpJj5c)](https://codecov.io/gh/pyodide/pytest-pyodide)
 
 


### PR DESCRIPTION
Based on the https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name there is a need to link to the workflow name, but if the workflow hasn't run actions, it doesn't generate the bage - so moved it to build.yml