### PR TITLE
pytest_pyodide.decorator: Use functools.update_wrapper

### DIFF
--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -435,6 +435,7 @@ class run_in_pyodide:
         new_ast_module = ast.Module(statements, type_ignores=[])
 
         wrapper = _create_outer_func(self._run, funcdef, f)
+        functools.update_wrapper(wrapper, f)
 
         # Store information needed by self._code_template
         self._mod = new_ast_module


### PR DESCRIPTION
The `@run_in_pyodide` decorator shows up in pytest when verbosity is high.
```
$ pytest -v -v -v packages/sympy
============================================================== test session starts ==============================================================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.4.0 -- /opt/conda/envs/pyodide-env/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/workspaces/pyodide/.hypothesis/examples'))
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspaces/pyodide
configfile: pyproject.toml
plugins: cov-4.1.0, hypothesis-6.97.0, httpserver-1.0.8, benchmark-4.0.0, asyncio-0.23.3, pyodide-0.1.dev109+gf1d4a53
asyncio: mode=Mode.STRICT
collected 1 item                                                                                                                                

sympy/test_sympy.py::sympy[node] <- pytest-pyodide/pytest_pyodide/decorator.py PASSED                                                     [100%]
```

The trivial improvement of this PR is to use `functool.update_wrapper`, which makes this disappear.