### PR TITLE
Add a test module for run_in_pyodide functions

### DIFF
--- a/pytest_pyodide/_decorator_in_pyodide.py
+++ b/pytest_pyodide/_decorator_in_pyodide.py
@@ -17,9 +17,11 @@ https://github.com/pyodide/pytest-pyodide/issues/43
 """
 
 import pickle
+import sys
 from base64 import b64decode, b64encode
 from inspect import isclass
 from io import BytesIO
+from types import ModuleType
 from typing import Any
 
 import pyodide_js
@@ -108,9 +110,15 @@ async def run_in_pyodide_main(
     mod = decode(mod64)
     args: tuple[Any] = decode(args64)
 
+    # Set up test module
+    MODULE_NAME = "test_module"
+    module = ModuleType(module_filename)
+    module.__file__ = module_filename
+    sys.modules[MODULE_NAME] = module
+    d = module.__dict__
+
     # Compile and execute the ast
     co = compile(mod, module_filename, "exec")
-    d: dict[str, Any] = {}
     exec(co, d)
 
     try:
@@ -142,6 +150,9 @@ async def run_in_pyodide_main(
         except ImportError:
             pass
         return (1, encode(e))
+    finally:
+        # Remove test module
+        del sys.modules[MODULE_NAME]
 
 
 __all__ = ["PyodideHandle", "encode"]


### PR DESCRIPTION
This makes name resolution a bit nicer. If we define a class A in the test,
1. A.__module__ is no longer "builtins"
2. sys.modules[A.__module__] points back to our current global scope
3. __file__ now has the correct value