### PR TITLE
Allow dynamic imports in node selenium code

### DIFF
--- a/pytest_pyodide/node_test_driver.js
+++ b/pytest_pyodide/node_test_driver.js
@@ -87,7 +87,7 @@ async function evalCode(uuid, code, eval_context) {
   let delim = uuid + ":UUID";
   console.log(delim);
   try {
-    vm.runInContext(wrapped_code, eval_context);
+    vm.runInContext(wrapped_code, eval_context, { importModuleDynamically: vm.constants?.USE_MAIN_CONTEXT_DEFAULT_LOADER });
     let result = JSON.stringify(await p);
     console.log(`${delim}\n0\n${result}\n${delim}`);
   } catch (e) {


### PR DESCRIPTION
Since node v20 we can pass `importModuleDynamically` to allow dynamic imports in code run by `vm.runInContext`. In older node versions, we fall back to the old behavior.

Tested manually.