### PR TITLE
Add node_extra_globals config

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,4 +3,11 @@ pytest_plugins = [
 ]
 
 # importing this fixture has a side effect of making the safari webdriver reused during the session
+from pytest_pyodide import get_global_config
 from pytest_pyodide.runner import use_global_safari_service  # noqa: F401
+
+
+def set_configs():
+    pytest_pyodide_config = get_global_config()
+
+    pytest_pyodide_config.add_node_extra_globals(["Request", "Response"])

--- a/pytest_pyodide/config.py
+++ b/pytest_pyodide/config.py
@@ -2,6 +2,7 @@
 Stores the global runtime configuration related to the pytest_pyodide package.
 """
 
+from collections.abc import Iterable, Sequence
 from typing import Literal
 
 RUNTIMES = Literal["chrome", "firefox", "node", "safari"]
@@ -31,6 +32,7 @@ class Config:
 
         # The script to be executed to initialize the runtime.
         self.initialize_script: str = "pyodide.runPython('');"
+        self.node_extra_globals = []
 
     def set_flags(self, runtime: RUNTIMES, flags: list[str]):
         self.flags[runtime] = flags
@@ -49,6 +51,12 @@ class Config:
 
     def get_initialize_script(self) -> str:
         return self.initialize_script
+
+    def add_node_extra_globals(self, l: Iterable[str]):
+        self.node_extra_globals.update(l)
+
+    def get_node_extra_globals(self) -> Sequence[str]:
+        return self.node_extra_globals
 
 
 SINGLETON = Config()

--- a/pytest_pyodide/node_test_driver.js
+++ b/pytest_pyodide/node_test_driver.js
@@ -5,7 +5,7 @@ const util = require("util");
 
 const baseUrl = process.argv[2];
 const distDir = process.argv[3];
-const EXTRA_GLOBALS = JSON.parse(process.env[NODE_TEST_DRIVER_EXTRA_GLOBALS]);
+const EXTRA_GLOBALS = JSON.parse(process.env.NODE_TEST_DRIVER_EXTRA_GLOBALS);
 
 
 const { loadPyodide } = require(`${distDir}/pyodide`);

--- a/pytest_pyodide/node_test_driver.js
+++ b/pytest_pyodide/node_test_driver.js
@@ -3,16 +3,17 @@ const readline = require("readline");
 const path = require("path");
 const util = require("util");
 
-let nodeFetch = globalThis.fetch;
-let baseUrl = process.argv[2];
-let distDir = process.argv[3];
+const baseUrl = process.argv[2];
+const distDir = process.argv[3];
+const EXTRA_GLOBALS = JSON.parse(process.env[NODE_TEST_DRIVER_EXTRA_GLOBALS]);
 
-let { loadPyodide } = require(`${distDir}/pyodide`);
+
+const { loadPyodide } = require(`${distDir}/pyodide`);
 process.chdir(distDir);
 
 // node requires full paths.
 function _fetch(path, ...args) {
-  return nodeFetch(new URL(path, baseUrl).toString(), ...args);
+  return fetch(new URL(path, baseUrl).toString(), ...args);
 }
 
 const context = {
@@ -20,24 +21,25 @@ const context = {
   path,
   process,
   require,
-  setTimeout,
   fetch: _fetch,
-  TextDecoder: util.TextDecoder,
-  TextEncoder: util.TextEncoder,
-  URL,
-  clearInterval,
+  TextDecoder,
+  TextEncoder,
+  setTimeout,
   clearTimeout,
   setInterval,
-  setTimeout,
-  Headers,
+  clearInterval,
   AbortController,
   AbortSignal,
 };
+for (const global of EXTRA_GLOBALS) {
+  context[global] = globalThis[global];
+}
+
 vm.createContext(context);
 vm.runInContext("globalThis.self = globalThis;", context);
 
 // Get rid of all colors in output of console.log, they mess us up.
-for (let key of Object.keys(util.inspect.styles)) {
+for (const key of Object.keys(util.inspect.styles)) {
   util.inspect.styles[key] = undefined;
 }
 

--- a/pytest_pyodide/node_test_driver.js
+++ b/pytest_pyodide/node_test_driver.js
@@ -5,7 +5,7 @@ const util = require("util");
 
 const baseUrl = process.argv[2];
 const distDir = process.argv[3];
-const EXTRA_GLOBALS = JSON.parse(process.env.NODE_TEST_DRIVER_EXTRA_GLOBALS);
+const EXTRA_GLOBALS = JSON.parse(process.env.PYTEST_PYODIDE_NODE_TEST_DRIVER_EXTRA_GLOBALS);
 
 
 const { loadPyodide } = require(`${distDir}/pyodide`);

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -1,4 +1,5 @@
 import json
+import os
 import textwrap
 from pathlib import Path
 
@@ -534,7 +535,9 @@ class NodeRunner(_BrowserBaseRunner):
 
     def init_node(self, jspi=False):
         curdir = Path(__file__).parent
-        self.p = pexpect.spawn("/bin/bash", timeout=60)
+        globals_str = json.dumps(self._config.get_node_extra_globals())
+        env = os.environ.copy() | {"NODE_TEST_DRIVER_EXTRA_GLOBALS": globals_str}
+        self.p = pexpect.spawn("/bin/bash", timeout=60, env=env)
         self.p.setecho(False)
         self.p.delaybeforesend = None
 

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -536,7 +536,7 @@ class NodeRunner(_BrowserBaseRunner):
     def init_node(self, jspi=False):
         curdir = Path(__file__).parent
         globals_str = json.dumps(self._config.get_node_extra_globals())
-        env = os.environ.copy() | {"NODE_TEST_DRIVER_EXTRA_GLOBALS": globals_str}
+        env = os.environ.copy() | {"PYTEST_PYODIDE_NODE_TEST_DRIVER_EXTRA_GLOBALS": globals_str}
         self.p = pexpect.spawn("/bin/bash", timeout=60, env=env)
         self.p.setecho(False)
         self.p.delaybeforesend = None

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -536,7 +536,9 @@ class NodeRunner(_BrowserBaseRunner):
     def init_node(self, jspi=False):
         curdir = Path(__file__).parent
         globals_str = json.dumps(self._config.get_node_extra_globals())
-        env = os.environ.copy() | {"PYTEST_PYODIDE_NODE_TEST_DRIVER_EXTRA_GLOBALS": globals_str}
+        env = os.environ.copy() | {
+            "PYTEST_PYODIDE_NODE_TEST_DRIVER_EXTRA_GLOBALS": globals_str
+        }
         self.p = pexpect.spawn("/bin/bash", timeout=60, env=env)
         self.p.setecho(False)
         self.p.delaybeforesend = None

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -12,3 +12,5 @@ def test_js_globals(selenium_standalone):
     hasattr(js, "setTimeout")
     hasattr(js, "clearTimeout")
     hasattr(js, "setInterval")
+    hasattr(js, "Request")
+    hasattr(js, "Response")


### PR DESCRIPTION
So we can add additional global variables to the node jsglobals without changes to pytest-pyodide.