### PR TITLE
Better handling for unpickle failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Framework :: Pytest"
 ]
 dynamic = ["version"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "pexpect",
   "pytest",

--- a/pytest_pyodide/_decorator_in_pyodide.py
+++ b/pytest_pyodide/_decorator_in_pyodide.py
@@ -119,7 +119,7 @@ async def run_in_pyodide_main(
         result = d[func_name](None, *args)
         if async_func:
             result = await result
-        return (0, encode(result))
+        return (0, encode(result), repr(result))
     except BaseException as e:
         try:
             # If tblib is present, we can show much better tracebacks.
@@ -141,7 +141,7 @@ async def run_in_pyodide_main(
 
         except ImportError:
             pass
-        return (1, encode(e))
+        return (1, encode(e), repr(result))
 
 
 __all__ = ["PyodideHandle", "encode"]


### PR DESCRIPTION
When we pickle the object, also store its repr. If we fail to unpickle, include the repr in the error message.

Also, add the info to the error using `add_node`. This requires Python 3.11 so I bumped the requires_python.

- [ ] Update tests