### PR TITLE
Resolve pylint R1729 by using generator in `any()`

### DIFF
--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -299,7 +299,7 @@ def pytest_collection_modifyitems(items: list[Any]) -> None:
     def _get_item_position(item):
         counter[0] += 1
         if any(
-            [re.match(r"^safari[\-$]?", el) for el in item.keywords._markers.keys()]
+            re.match(r"^safari[\-$]?", el) for el in item.keywords._markers.keys()
         ) and _has_standalone_fixture(item):
             return counter[0] - OFFSET
         return counter[0]


### PR DESCRIPTION
A generator can be used here (cf. [`use-a-generator / R1729`](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-a-generator.html))