### PR TITLE
selenium_jspi: don't pass experimental flag with chrome >= 137

### DIFF
--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -455,7 +455,7 @@ class SeleniumChromeRunner(_SeleniumBaseRunner):
         )
         driver.quit()
 
-        if jspi and chrome_version >= 137:
+        if jspi and chrome_version < 137:
             options.add_argument("--enable-features=WebAssemblyExperimentalJSPI")
             options.add_argument("--enable-experimental-webassembly-features")
         for flag in self._config.get_flags("chrome"):

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -450,7 +450,9 @@ class SeleniumChromeRunner(_SeleniumBaseRunner):
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
         driver = Chrome(options=options)
-        chrome_version = int(driver.capabilities.get('browserVersion', '0').split('.')[0])
+        chrome_version = int(
+            driver.capabilities.get("browserVersion", "0").split(".")[0]
+        )
         print(chrome_version)
         driver.quit()
 

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -453,7 +453,6 @@ class SeleniumChromeRunner(_SeleniumBaseRunner):
         chrome_version = int(
             driver.capabilities.get("browserVersion", "0").split(".")[0]
         )
-        print(chrome_version)
         driver.quit()
 
         if jspi and chrome_version >= 137:

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -449,7 +449,12 @@ class SeleniumChromeRunner(_SeleniumBaseRunner):
         options = Options()
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
-        if jspi:
+        driver = Chrome(options=options)
+        chrome_version = int(driver.capabilities.get('browserVersion', '0').split('.')[0])
+        print(chrome_version)
+        driver.quit()
+
+        if jspi and chrome_version >= 137:
             options.add_argument("--enable-features=WebAssemblyExperimentalJSPI")
             options.add_argument("--enable-experimental-webassembly-features")
         for flag in self._config.get_flags("chrome"):


### PR DESCRIPTION
JSPI is enabled by default in this case.

Resolves #163.