### PR TITLE
Resolve pylint R1716 by chaining the comparison

### DIFF
--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -345,7 +345,7 @@ def _locate_funcdef(
         ):
             statements.append(node)
 
-        if node.end_lineno and node.end_lineno > func_line_no > node.lineno:
+        if node.end_lineno and (node.lineno < func_line_no < node.end_lineno):
             it = iter(node.body)  # type: ignore[attr-defined]
             continue
 


### PR DESCRIPTION
This PR resolves the [`chained-comparison / R1716`](https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/chained-comparison.html) warning.