### PR TITLE
Resolve pylint R1705

### DIFF
--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -372,9 +372,8 @@ class run_in_pyodide:
             # def f():
             #   pass
             return run_in_pyodide(**kwargs)(function)
-        else:
-            # Just do normal __new__ behavior
-            return object.__new__(cls)
+        # Just do normal __new__ behavior
+        return object.__new__(cls)
 
     def __init__(
         self,

--- a/pytest_pyodide/run_tests_inside_pyodide.py
+++ b/pytest_pyodide/run_tests_inside_pyodide.py
@@ -106,8 +106,7 @@ def _remove_pytest_capture_title(
     ret_data = "\n".join(lines[1:])
     if re.search(r"\S", ret_data):
         return ret_data
-    else:
-        return None
+    return None
 
 
 def run_test_in_pyodide(node_tree_id, selenium, ignore_fail=False):

--- a/pytest_pyodide/runner.py
+++ b/pytest_pyodide/runner.py
@@ -363,9 +363,8 @@ class _SeleniumBaseRunner(_BrowserBaseRunner):
         retval = self.driver.execute_async_script(wrapper % (code, check_code))
         if retval[0] == 0:
             return retval[1]
-        else:
-            print("JavascriptException message: ", retval[3])
-            raise JavascriptException(retval[1], retval[2])
+        print("JavascriptException message: ", retval[3])
+        raise JavascriptException(retval[1], retval[2])
 
     @property
     def urls(self):
@@ -416,8 +415,7 @@ class _PlaywrightBaseRunner(_BrowserBaseRunner):
         retval = self.driver.evaluate(wrapper % (code, check_code))
         if retval[0] == 0:
             return retval[1]
-        else:
-            raise JavascriptException(retval[1], retval[2])
+        raise JavascriptException(retval[1], retval[2])
 
 
 class SeleniumFirefoxRunner(_SeleniumBaseRunner):
@@ -643,5 +641,4 @@ class NodeRunner(_BrowserBaseRunner):
         self.p.expect_exact(f"\r\n{cmd_id}:UUID\r\n")
         if success:
             return json.loads(self.p.before.decode().replace("undefined", "null"))
-        else:
-            raise JavascriptException("", self.p.before.decode())
+        raise JavascriptException("", self.p.before.decode())

--- a/pytest_pyodide/utils.py
+++ b/pytest_pyodide/utils.py
@@ -28,8 +28,7 @@ def parse_driver_timeout(node) -> float | None:
     mark = node.get_closest_marker("driver_timeout")
     if mark is None:
         return None
-    else:
-        return mark.args[0]  # type: ignore[no-any-return]
+    return mark.args[0]  # type: ignore[no-any-return]
 
 
 def parse_xfail_browsers(node) -> dict[str, str]:


### PR DESCRIPTION
This PR resolves the [`no-else-return / R1705`](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html) warning.