### PR TITLE
Resolve pylint R1720

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ lint.select = [
   "PLC",    # pylint conventions
   "PLE",    # pylint errors
   "UP",     # pyupgrade
+  "RET506",
 ]
 lint.ignore = ["E402", "E501", "E731", "E741"]
 # line-length = 219  # E501: Recommended goal is 88 to match black

--- a/pytest_pyodide/decorator.py
+++ b/pytest_pyodide/decorator.py
@@ -454,8 +454,7 @@ class run_in_pyodide:
         result = _decode(selenium, result, status, repr)
         if status:
             raise result
-        else:
-            return result
+        return result
 
     def _code_template(self, args: tuple[Any, ...]) -> str:
         """


### PR DESCRIPTION
This PR resolves the [`no-else-raise / R1720`](https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/no-else-raise.html) / [`superfluous-else-raise (RET506)`](https://docs.astral.sh/ruff/rules/superfluous-else-raise/#superfluous-else-raise-ret506) warning.

Similar to #170.