### PR TITLE
Add newly resolved lints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ lint.select = [
   "PLC",    # pylint conventions
   "PLE",    # pylint errors
   "UP",     # pyupgrade
+  "PLR1716",
+  "RET505",
   "RET506",
 ]
 lint.ignore = ["E402", "E501", "E731", "E741"]


### PR DESCRIPTION
This PR follows the [suggestion](https://github.com/pyodide/pytest-pyodide/pull/170#issuecomment-3120445319) of @hoodmane to introduce new lints into the config.

In short:
- #168 relates to [`boolean-chained-comparison (PLR1716)`](https://docs.astral.sh/ruff/rules/boolean-chained-comparison/)
- #170 relates to [`superfluous-else-return (RET505)`](https://docs.astral.sh/ruff/rules/superfluous-else-return/)

Note that the above rules have _automatic fix available_, so the [current config of pre-commit](https://github.com/pyodide/pytest-pyodide/blob/f1b67d1424fc0591979cb38ee2418279f2612d5c/.pre-commit-config.yaml#L22) will handle them and this change will not introduce an extra cost for the developers.

The remaining PRs:
- #166,
- #169,

do not relate to any ruff rule (at the moment).