### PR TITLE
Resolve pylint R1711

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ lint.select = [
   "PLC",    # pylint conventions
   "PLE",    # pylint errors
   "UP",     # pyupgrade
+  "PLR1711",
   "PLR1716",
   "RET505",
   "RET506",

--- a/pytest_pyodide/hook.py
+++ b/pytest_pyodide/hook.py
@@ -281,7 +281,6 @@ def modifyitems_run_in_pyodide(items: list[Any]):
             x.pyodide_runtime = runtime
             new_items.append(x)
     items[:] = new_items
-    return
 
 
 def pytest_collection_modifyitems(items: list[Any]) -> None:


### PR DESCRIPTION
Resolves the [`useless-return / R1711`](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/useless-return.html) / [`useless-return (PLR1711)`](https://docs.astral.sh/ruff/rules/useless-return/) warning.